### PR TITLE
Add jshint to the tests (fix #6)

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,21 @@
+{
+  "asi": true,
+  "bitwise": true,
+  "camelcase": true,
+  "eqeqeq": true,
+  "forin": true,
+  "freeze": true,
+  "immed": true,
+  "indent": 2,
+  "latedef": true,
+  "noarg": true,
+  "nonbsp": true,
+  "nonew": true,
+  "quotmark": "single",
+  "undef": false,
+  "unused": false,
+  "strict": false,
+  "trailing": true,
+
+  "node": true
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "memcached": "0.2.8"
   },
   "devDependencies": {
-    "tap": "0.4.8"
+    "jshint": "2.5.x",
+    "tap": "0.4.8",
+    "walk": "2.3.x"
   }
 }

--- a/test/email_record_tests.js
+++ b/test/email_record_tests.js
@@ -6,7 +6,7 @@ function now() {
 }
 
 function simpleEmailRecord() {
-  return new (emailRecord(500, 2, now))
+  return new (emailRecord(500, 2, now))()
 }
 
 test(

--- a/test/jshint.js
+++ b/test/jshint.js
@@ -1,0 +1,75 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+var test = require('tap').test
+var fs = require('fs')
+var jshint = require('jshint').JSHINT
+var path = require('path')
+var walk = require('walk')
+var util = require('util')
+
+var jshintrc
+var filesToLint = []
+
+test(
+  'jshint is setup',
+  function (t) {
+    jshintrc = JSON.parse(fs.readFileSync(path.join(__dirname, '../.jshintrc')).toString())
+
+    t.type(jshintrc, 'object', '.jshintrc is readable')
+
+    var walker = walk.walk(path.join(__dirname, '..'), { filters: ['node_modules'] })
+    walker.on('file', function(root, fStat, next) {
+      var f = path.join(root, fStat.name)
+      if (/\.js$/.test(f)) {
+        filesToLint.push(f)
+      }
+      next()
+    })
+    walker.on('end', function () {
+      t.equal(filesToLint.length > 4, true, 'files to lint can be found')
+      t.end()
+    })
+  }
+)
+
+test(
+  'linting produces no errors',
+  function (t) {
+    var errors = []
+    var unreadableFiles = []
+
+    function checkNext() {
+      if (!filesToLint.length) {
+        var buf = ''
+        if (errors.length) {
+          buf = util.format('\n        %d errors:\n* ', errors.length)
+          buf += errors.join('\n* ')
+        }
+
+        t.equal(unreadableFiles.join('\n'), '', 'all files can be read')
+        t.equal(buf, '', 'no errors have been found')
+        t.end()
+        return
+      }
+
+      var f = filesToLint.shift()
+      fs.readFile(f.toString(), function (err, data) {
+        if (err) {
+          unreadableFiles.push(f)
+        } else {
+          f = path.relative(process.cwd(), f)
+          if (!jshint(data.toString(), jshintrc)) {
+            jshint.errors.forEach(function(e) {
+              if (e) {
+                errors.push(util.format('%s %s:%d - %s', e.id, f, e.line, e.reason))
+              }
+            })
+          }
+          checkNext()
+        }
+      })
+    }
+    checkNext()
+  }
+)


### PR DESCRIPTION
This is inspired by the test of the same name in browserid-local-verify
(https://github.com/mozilla/browserid-local-verify/blob/404bdcd158094aaaeb412b8eb0263243c79f8b92/tests/jshint.js) and enables all of the checks that pass.
