### PR TITLE
record coverage data from the main process

### DIFF
--- a/bin/customs_server.js
+++ b/bin/customs_server.js
@@ -18,6 +18,14 @@ var IpRecord = require('../ip_record')(BLOCK_INTERVAL_MS)
 var P = require('bluebird')
 P.promisifyAll(Memcached.prototype)
 
+function shutdown() {
+  process.nextTick(process.exit)
+}
+
+if (process.env.ASS_CODE_COVERAGE) {
+  process.on('SIGINT', shutdown)
+}
+
 var mc = new Memcached(
   config.memcached,
   {

--- a/test/customs_server_stub.js
+++ b/test/customs_server_stub.js
@@ -2,4 +2,5 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-require('../bin/customs_server.js')
+require('ass')
+require('../bin/customs_server')


### PR DESCRIPTION
Mostly the same as https://github.com/chilts/fxa-auth-db-server/pull/1/files to get full coverage of the daemon.
