### PR TITLE
Fix SQS API

### DIFF
--- a/bans/handler.js
+++ b/bans/handler.js
@@ -64,6 +64,9 @@ module.exports = function (mc, log) {
   }
 
   function handleBan(message, cb) {
+    if (!cb) {
+      cb = function () {}
+    }
     if (message.ban && message.ban.ip) {
       blockIp(message.ban.ip, cb)
     }


### PR DESCRIPTION
This can be tested from the AWS web console like this:
1. create a test queue
2. give all permissions to everybody
3. send a manual message like this one:
   
   ```
   {"Message":"{\"ban\":{\"ip\":\"192.168.0.2\"}}"}
   ```

Then run the customs server with the queue region and URL:

```
BANS_REGION="ap-southeast-2" BANS_QUEUE_URL="https://sqs.ap-southeast-2.amazonaws.com/12345678/cs-sqs-test" node bin/customs_server.js
```

and use the `check` API before and after sending the SQS message:

```
curl -H "Content-Type: application/json" -d '{"ip":"192.168.0.2","action":"accountLogin"}' http://127.0.0.1:7000/check
```
