### PR TITLE
expose all configuration settings to the environment; add option memcache.address to work with previous puppet settings

### DIFF
--- a/bin/customs_server.js
+++ b/bin/customs_server.js
@@ -27,8 +27,13 @@ if (process.env.ASS_CODE_COVERAGE) {
   process.on('SIGINT', shutdown)
 }
 
+var memcacheAddress = config.memcache.address
+if (!memcacheAddress) {
+  memcacheAddress = config.memcache.host + ':' + config.memcache.port
+}
+
 var mc = new Memcached(
-  config.memcache.host + ':' + config.memcache.port,
+  memcacheAddress,
   {
     timeout: 500,
     retries: 1,

--- a/config/config.js
+++ b/config/config.js
@@ -41,25 +41,34 @@ module.exports = function (fs, path, url, convict) {
       blockIntervalSeconds: {
         doc: 'Duration of a manual ban',
         default: 60 * 60 * 24,
-        format: 'nat'
+        format: 'nat',
+        env: 'BLOCK_INTERVAL_SECONDS'
       },
       rateLimitIntervalSeconds: {
         doc: 'Duration of automatic throttling',
         default: 60 * 15,
-        format: 'nat'
+        format: 'nat',
+        env: 'RATE_LIMIT_INTERVAL_SECONDS'
       },
       maxEmails: {
         doc: 'Number of emails sent within rateLimitIntervalSeconds before throttling',
         default: 3,
-        format: 'nat'
+        format: 'nat',
+        env: 'MAX_EMAILS'
       },
       maxBadLogins: {
         doc: 'Number failed login attempts within rateLimitIntervalSeconds before throttling',
         default: 2,
-        format: 'nat'
+        format: 'nat',
+        env: 'MAX_BAD_LOGINS'
       }
     },
     memcache: {
+      address: {
+        doc: 'Hostname/IP:Port of the memcache server; trumps host and port if set',
+        default: '',
+        env: 'MEMCACHE_ADDRESS'
+      },
       host: {
         doc: 'Hostname / IP of the memcache server',
         default: '127.0.0.1',
@@ -74,7 +83,8 @@ module.exports = function (fs, path, url, convict) {
       recordLifetimeSeconds: {
         doc: 'Memcache record expiry',
         default: 900,
-        format: 'nat'
+        format: 'nat',
+        env: 'RECORD_LIFETIME_SECONDS'
       }
     },
     bans: {


### PR DESCRIPTION
In the previous production config of customs-server, we overrode settings for:

```
logLevel = info, 
maxBadLogins = 10, 
memcached = hostname:11211, 
port = 7000
```

In the switch to convict, two problems:
1. maxBadLogins was not made available to be configured in the environment (or by config file). Once I had to change that, I figured all of them should be exposed. 

(Note for convict feature requests : in `rc` _all_ config values are exposed to the environment).
1. the location of memcached was host:port, but in the port to convict, it is looking for a host and a port separately. I don't want to change the setting in puppet, so I just fix it here to look for a 'host:port' value first.
