### PR TITLE
Fix toLowerCase() on undefined email

### DIFF
--- a/bin/customs_server.js
+++ b/bin/customs_server.js
@@ -90,7 +90,7 @@ function normalizedEmail(rawEmail) {
 api.post(
   '/check',
   function (req, res, next) {
-    var email = normalizedEmail(req.body.email)
+    var email = req.body.email
     var ip = req.body.ip
     var action = req.body.action
 
@@ -100,6 +100,8 @@ api.post(
       res.send(500, err)
       return next()
     }
+
+    email = normalizedEmail(email)
 
     fetchRecords(email, ip)
       .spread(
@@ -141,7 +143,7 @@ api.post(
 api.post(
   '/failedLoginAttempt',
   function (req, res, next) {
-    var email = normalizedEmail(req.body.email)
+    var email = req.body.email
     var ip = req.body.ip
     if (!email || !ip) {
       var err = {code: 'MissingParameters', message: 'email and ip are both required'}
@@ -149,6 +151,8 @@ api.post(
       res.send(500, err)
       next()
     }
+
+    email = normalizedEmail(email)
 
     fetchRecords(email, ip)
       .spread(
@@ -182,13 +186,15 @@ api.post(
 api.post(
   '/passwordReset',
   function (req, res, next) {
-    var email = normalizedEmail(req.body.email)
+    var email = req.body.email
     if (!email) {
       var err = {code: 'MissingParameters', message: 'email is required'}
       log.error({ op: 'request.passwordReset', email: email, err: err })
       res.send(500, err)
       next()
     }
+
+    email = normalizedEmail(email)
 
     mc.getAsync(email)
       .then(EmailRecord.parse, EmailRecord.parse)
@@ -215,13 +221,15 @@ api.post(
 api.post(
   '/blockEmail',
   function (req, res, next) {
-    var email = normalizedEmail(req.body.email)
+    var email = req.body.email
     if (!email) {
       var err = {code: 'MissingParameters', message: 'email is required'}
       log.error({ op: 'request.blockEmail', email: email, err: err })
       res.send(500, err)
       next()
     }
+
+    email = normalizedEmail(email)
 
     handleBan({ ban: { email: email } })
       .then(

--- a/test/remote/block_email_tests.js
+++ b/test/remote/block_email_tests.js
@@ -51,6 +51,7 @@ test(
         t.equal(res.statusCode, 500, 'bad request returns a 500')
         t.type(obj.code, 'string', 'bad request returns an error code')
         t.type(obj.message, 'string', 'bad request returns an error message')
+        t.equal(obj.message, 'email is required', 'correct error message if missing params')
         t.end()
       }
     )

--- a/test/remote/block_ip_tests.js
+++ b/test/remote/block_ip_tests.js
@@ -51,6 +51,7 @@ test(
         t.equal(res.statusCode, 500, 'bad request returns a 500')
         t.type(obj.code, 'string', 'bad request returns an error code')
         t.type(obj.message, 'string', 'bad request returns an error message')
+        t.equal(obj.message, 'ip is required', 'correct error message if missing params')
         t.end()
       }
     )

--- a/test/remote/check_tests.js
+++ b/test/remote/check_tests.js
@@ -53,6 +53,7 @@ test(
         t.equal(res.statusCode, 500, 'bad request returns a 500')
         t.type(obj.code, 'string', 'bad request returns an error code')
         t.type(obj.message, 'string', 'bad request returns an error message')
+        t.equal(obj.message, 'email, ip and action are all required', 'correct error message if missing params')
         t.end()
       }
     )
@@ -67,6 +68,7 @@ test(
         t.equal(res.statusCode, 500, 'bad request returns a 500')
         t.type(obj.code, 'string', 'bad request returns an error code')
         t.type(obj.message, 'string', 'bad request returns an error message')
+        t.equal(obj.message, 'email, ip and action are all required', 'correct error message if missing params')
         t.end()
       }
     )

--- a/test/remote/failed_login_attempt_tests.js
+++ b/test/remote/failed_login_attempt_tests.js
@@ -51,6 +51,22 @@ test(
         t.equal(res.statusCode, 500, 'bad request returns a 500')
         t.type(obj.code, 'string', 'bad request returns an error code')
         t.type(obj.message, 'string', 'bad request returns an error message')
+        t.equal(obj.message, 'email and ip are both required', 'correct error message if missing params')
+        t.end()
+      }
+    )
+  }
+)
+
+test(
+  'missing email',
+  function (t) {
+    client.post('/failedLoginAttempt', { email: TEST_EMAIL },
+      function (err, req, res, obj) {
+        t.equal(res.statusCode, 500, 'bad request returns a 500')
+        t.type(obj.code, 'string', 'bad request returns an error code')
+        t.type(obj.message, 'string', 'bad request returns an error message')
+        t.equal(obj.message, 'email and ip are both required', 'correct error message if missing params')
         t.end()
       }
     )
@@ -65,6 +81,7 @@ test(
         t.equal(res.statusCode, 500, 'bad request returns a 500')
         t.type(obj.code, 'string', 'bad request returns an error code')
         t.type(obj.message, 'string', 'bad request returns an error message')
+        t.equal(obj.message, 'email and ip are both required', 'correct error message if missing params')
         t.end()
       }
     )

--- a/test/remote/password_reset_tests.js
+++ b/test/remote/password_reset_tests.js
@@ -50,6 +50,7 @@ test(
         t.equal(res.statusCode, 500, 'bad request returns a 500')
         t.type(obj.code, 'string', 'bad request returns an error code')
         t.type(obj.message, 'string', 'bad request returns an error message')
+        t.equal(obj.message, 'email is required', 'correct error message if missing params')
         t.end()
       }
     )


### PR DESCRIPTION
If incoming email is not sent, then the .toLowerCase() inside
normalizedEmail() fails and gives an internal server error. Instead,
check that the param is provided first, then do the normalisation.
