### PR TITLE
Block all actions for emails that are explicitly banned

### DIFF
--- a/email_record.js
+++ b/email_record.js
@@ -81,8 +81,11 @@ module.exports = function (RATE_LIMIT_INTERVAL_MS, BLOCK_INTERVAL_MS, MAX_EMAILS
 
   EmailRecord.prototype.isBlocked = function () {
     var rateLimited = !!(this.rl && (now() - this.rl < RATE_LIMIT_INTERVAL_MS))
-    var banned = !!(this.bk && (now() - this.bk < BLOCK_INTERVAL_MS))
-    return rateLimited || banned
+    return rateLimited || this.isBanned()
+  }
+
+  EmailRecord.prototype.isBanned = function () {
+    return !!(this.bk && (now() - this.bk < BLOCK_INTERVAL_MS))
   }
 
   EmailRecord.prototype.block = function () {
@@ -105,7 +108,7 @@ module.exports = function (RATE_LIMIT_INTERVAL_MS, BLOCK_INTERVAL_MS, MAX_EMAILS
   }
 
   EmailRecord.prototype.update = function (action) {
-    if (EMAIL_ACTIONS.indexOf(action) === -1) {
+    if (!this.isBanned() && EMAIL_ACTIONS.indexOf(action) === -1) {
       return 0
     }
 

--- a/test/local/email_record_tests.js
+++ b/test/local/email_record_tests.js
@@ -208,6 +208,19 @@ test(
     t.equal(er.update('accountCreate'), 0, 'email action above the email limit')
     t.equal(er.isBlocked(), true, 'account is now blocked')
     t.equal(er.update('accountCreate'), 0, 'email action in a blocked account')
+
+    er.rl = 2000
+    t.equal(er.isBlocked(), true, 'account is blocked')
+    t.equal(er.isBanned(), false, 'account is not outright banned')
+    t.equal(er.update('accountCreate'), 1, 'email action is blocked')
+    t.equal(er.update('accountLogin'), 0, 'non-email action is not blocked')
+    er.rl = 0
+    er.bk = 2000
+    t.equal(er.isBlocked(), true, 'account is blocked')
+    t.equal(er.isBanned(), true, 'account is outright banned')
+    t.equal(er.update('accountCreate'), 1, 'email action is blocked')
+    t.equal(er.update('accountLogin'), 1, 'non-email action is blocked')
+
     t.end()
   }
 )


### PR DESCRIPTION
The `email_record.update` function is the final arbiter of whether an email address gets blocked from performing an action.  It currently short-circuits to allow any non-email-sending action through regardless of the state of the record.

This doesn't work well for explicit bans of email addresses (as might be generated through our SQS ban queue) which AFAICT should cause _all_ actions with that email address to be blocked.  For example, if I send a message to ban a particular email, I would expect to be blocked from logging in with that email despite it being a non-email-sending action.

This PR refactors the logic to distinguish these two cases of "blocked" and "banned".

@fmarier can you please sanity-check the behaviour here, and @chilts to r? since it's a good excuse to dig into this codebase.
