### PR TITLE
Add task for tagging release and fix some jshint whining

### DIFF
--- a/grunttasks/bump.js
+++ b/grunttasks/bump.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// takes care of bumping the version number in package.json
+
+module.exports = function (grunt) {
+  'use strict';
+
+  grunt.config('bump', {
+    options: {
+      files: ['package.json', 'npm-shrinkwrap.json'],
+      bumpVersion: true,
+      commit: true,
+      commitMessage: 'Release v%VERSION%',
+      commitFiles: ['package.json', 'npm-shrinkwrap.json', 'CHANGELOG'],
+      createTag: true,
+      tagName: 'v%VERSION%',
+      tagMessage: 'Version %VERSION%',
+      push: false,
+      pushTo: 'origin',
+      gitDescribeOptions: '--tags --always --abrev=1 --dirty=-d'
+    }
+  });
+};
+

--- a/grunttasks/copyright.js
+++ b/grunttasks/copyright.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (grunt) {
+  'use strict';
+
+  grunt.config('copyright', {
+    app: {
+      options: {
+        pattern: 'This Source Code Form is subject to the terms of the Mozilla Public'
+      },
+      src: [
+        '{,config/}*.js',
+        '{,bans/,bin/,grunttasks/,scripts/,test/}*.js'
+      ]
+    },
+    tests: {
+      options: {
+        pattern: 'Any copyright is dedicated to the Public Domain.'
+      },
+      src: [
+        'test/{remote,local}/*.js'
+      ]
+    }
+  })
+}

--- a/grunttasks/jshint.js
+++ b/grunttasks/jshint.js
@@ -5,10 +5,12 @@
 module.exports = function (grunt) {
   'use strict';
 
-  require('load-grunt-tasks')(grunt);
-
-  grunt.loadTasks('grunttasks')
-
-  grunt.registerTask('default', ['lint', 'copyright', 'validate-shrinkwrap'])
-  grunt.registerTask('lint', ['jshint'])
+  grunt.config('jshint', {
+    files: [
+      '{,bans/,bin/,config/,grunttasks/,scripts/,test/**/}*.js'
+    ],
+    options: {
+      jshintrc: '.jshintrc'
+    }
+  })
 }

--- a/grunttasks/version.js
+++ b/grunttasks/version.js
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//
+// A task to stamp a new version.
+//
+// Before running this task you should update CHANGELOG with the
+// changes for this release. Protip: you only need to make changes
+// to CHANGELOG; this task will add and commit for you.
+//
+// * version is updated in package.json
+// * git tag with version name is created.
+// * git commit with updated package.json created.
+//
+// NOTE: This task will not push this commit for you.
+//
+
+module.exports = function (grunt) {
+  'use strict';
+
+  grunt.registerTask('version', [
+    'bump-only:minor',
+    'bump-commit'
+  ]);
+
+  grunt.registerTask('version:patch', [
+    'bump-only:patch',
+    'bump-commit'
+  ]);
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-customs-server",
-  "version": "0.5.0",
+  "version": "0.33.0",
   "dependencies": {
     "ass": {
       "version": "0.0.4",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,27 +9,27 @@
       "dependencies": {
         "blanket": {
           "version": "1.1.6",
-          "from": "blanket@~1.1.5",
+          "from": "blanket@>=1.1.5 <1.2.0",
           "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
           "dependencies": {
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~1.0.2",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             },
             "falafel": {
               "version": "0.1.6",
-              "from": "falafel@~0.1.6",
+              "from": "falafel@>=0.1.6 <0.2.0",
               "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
             },
             "xtend": {
               "version": "2.1.2",
-              "from": "xtend@~2.1.1",
+              "from": "xtend@>=2.1.1 <2.2.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "dependencies": {
                 "object-keys": {
                   "version": "0.4.0",
-                  "from": "object-keys@~0.4.0",
+                  "from": "object-keys@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                 }
               }
@@ -38,17 +38,17 @@
         },
         "temp": {
           "version": "0.6.0",
-          "from": "temp@~0.6.0",
+          "from": "temp@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/temp/-/temp-0.6.0.tgz",
           "dependencies": {
             "rimraf": {
               "version": "2.1.4",
-              "from": "rimraf@~2.1.4",
+              "from": "rimraf@>=2.1.4 <2.2.0",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "1.2.3",
-                  "from": "graceful-fs@~1",
+                  "from": "graceful-fs@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                 }
               }
@@ -62,12 +62,12 @@
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@~0.2.9",
+          "from": "async@>=0.2.9 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "cheerio": {
           "version": "0.12.4",
-          "from": "cheerio@~0.12.4",
+          "from": "cheerio@>=0.12.4 <0.13.0",
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.12.4.tgz",
           "dependencies": {
             "cheerio-select": {
@@ -77,35 +77,35 @@
               "dependencies": {
                 "CSSselect": {
                   "version": "0.7.0",
-                  "from": "CSSselect@0.x",
+                  "from": "CSSselect@>=0.0.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.7.0.tgz",
                   "dependencies": {
                     "CSSwhat": {
                       "version": "0.4.7",
-                      "from": "CSSwhat@0.4",
+                      "from": "CSSwhat@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
                     },
                     "domutils": {
                       "version": "1.4.3",
-                      "from": "domutils@1.4",
+                      "from": "domutils@>=1.4.0 <1.5.0",
                       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                       "dependencies": {
                         "domelementtype": {
-                          "version": "1.1.3",
-                          "from": "domelementtype@1",
-                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                          "version": "1.3.0",
+                          "from": "domelementtype@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                         }
                       }
                     },
                     "boolbase": {
                       "version": "1.0.0",
-                      "from": "boolbase@~1.0.0",
+                      "from": "boolbase@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
                     },
                     "nth-check": {
-                      "version": "1.0.0",
-                      "from": "nth-check@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.0.tgz"
+                      "version": "1.0.1",
+                      "from": "nth-check@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
                     }
                   }
                 }
@@ -118,27 +118,27 @@
               "dependencies": {
                 "domhandler": {
                   "version": "2.0.3",
-                  "from": "domhandler@2.0",
+                  "from": "domhandler@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.0.3.tgz"
                 },
                 "domutils": {
                   "version": "1.1.6",
-                  "from": "domutils@1.1",
+                  "from": "domutils@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz"
                 },
                 "domelementtype": {
-                  "version": "1.1.3",
-                  "from": "domelementtype@1",
-                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                  "version": "1.3.0",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@1.0",
+                  "from": "readable-stream@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -148,12 +148,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -162,12 +162,12 @@
             },
             "underscore": {
               "version": "1.4.4",
-              "from": "underscore@~1.4",
+              "from": "underscore@>=1.4.0 <1.5.0",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
             },
             "entities": {
               "version": "0.5.0",
-              "from": "entities@0.x",
+              "from": "entities@>=0.0.0 <1.0.0",
               "resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz"
             }
           }
@@ -181,7 +181,7 @@
       "dependencies": {
         "aws-sdk-apis": {
           "version": "3.1.10",
-          "from": "aws-sdk-apis@3.x",
+          "from": "aws-sdk-apis@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/aws-sdk-apis/-/aws-sdk-apis-3.1.10.tgz"
         },
         "xml2js": {
@@ -215,12 +215,12 @@
       "dependencies": {
         "mv": {
           "version": "2.0.3",
-          "from": "mv@~2",
+          "from": "mv@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.5.0",
-              "from": "mkdirp@~0.5.0",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
@@ -232,19 +232,19 @@
             },
             "ncp": {
               "version": "0.6.0",
-              "from": "ncp@~0.6.0",
+              "from": "ncp@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "rimraf@~2.2.8",
+              "from": "rimraf@>=2.2.8 <2.3.0",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             }
           }
         },
         "dtrace-provider": {
           "version": "0.2.8",
-          "from": "dtrace-provider@^0.2.8",
+          "from": "dtrace-provider@>=0.2.8 <0.3.0",
           "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
         }
       }
@@ -266,32 +266,32 @@
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "nomnom@>= 1.5.x",
+                  "from": "nomnom@>=1.5.0",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "underscore@~1.6.0",
+                      "from": "underscore@>=1.6.0 <1.7.0",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "chalk@~0.4.0",
+                      "from": "chalk@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "has-color@~0.1.0",
+                          "from": "has-color@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "ansi-styles@~1.0.0",
+                          "from": "ansi-styles@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "strip-ansi@~0.1.0",
+                          "from": "strip-ansi@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -300,7 +300,7 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "JSV@>= 4.0.x",
+                  "from": "JSV@>=4.0.0",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
@@ -324,12 +324,12 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@~0.0.1",
+              "from": "minimist@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
@@ -348,17 +348,17 @@
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@~0.1.22",
+          "from": "async@>=0.1.22 <0.2.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@~1.3.3",
+          "from": "coffee-script@>=1.3.3 <1.4.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@~0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
@@ -368,37 +368,37 @@
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "eventemitter2@~0.4.13",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@~0.1.2",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~3.2.9",
+              "from": "glob@>=3.2.1 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -407,147 +407,159 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@~3.1.21",
+          "from": "glob@>=3.1.21 <3.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@~1",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@1",
+              "from": "inherits@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@~0.2.11",
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@~0.2.12",
+          "from": "minimatch@>=0.2.12 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@~1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@~1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@1",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@~2.2.8",
+          "from": "rimraf@>=2.2.8 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@~0.9.2",
+          "from": "lodash@>=0.9.2 <0.10.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@~2.2.1",
+          "from": "underscore.string@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
-          "version": "1.0.8",
-          "from": "which@~1.0.5",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
+          "version": "1.0.9",
+          "from": "which@>=1.0.5 <1.1.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@~2.0.5",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@~ 0.1.11",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "underscore@~1.7.0",
+                  "from": "underscore@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@~2.4.0",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~ 1.0.2",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@~0.1.1",
+          "from": "exit@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@~0.1.0",
+          "from": "getobject@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "grunt-legacy-util@~0.2.0",
+          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.1",
-          "from": "grunt-legacy-log@~0.1.0",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "underscore.string@~2.3.3",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
+        }
+      }
+    },
+    "grunt-bump": {
+      "version": "0.3.0",
+      "from": "grunt-bump@0.3.0",
+      "resolved": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.3.0.tgz",
+      "dependencies": {
+        "semver": {
+          "version": "4.2.2",
+          "from": "semver@>=4.2.2 <4.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.2.2.tgz"
         }
       }
     },
@@ -558,44 +570,44 @@
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@~1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@1",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@~0.1.0",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~3.2.9",
+              "from": "glob@>=3.2.1 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -604,14 +616,14 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "resolve": {
           "version": "0.3.1",
-          "from": "resolve@~0.3.1",
+          "from": "resolve@>=0.3.1 <0.4.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
         }
       }
@@ -623,7 +635,7 @@
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         }
       }
@@ -640,27 +652,27 @@
       "dependencies": {
         "cli-color": {
           "version": "0.2.3",
-          "from": "cli-color@^0.2.3",
+          "from": "cli-color@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
           "dependencies": {
             "es5-ext": {
               "version": "0.9.2",
-              "from": "es5-ext@~0.9.2",
+              "from": "es5-ext@>=0.9.2 <0.10.0",
               "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
             },
             "memoizee": {
               "version": "0.2.6",
-              "from": "memoizee@~0.2.5",
+              "from": "memoizee@>=0.2.5 <0.3.0",
               "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
               "dependencies": {
                 "event-emitter": {
                   "version": "0.2.2",
-                  "from": "event-emitter@~0.2.2",
+                  "from": "event-emitter@>=0.2.2 <0.3.0",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
                 },
                 "next-tick": {
                   "version": "0.1.0",
-                  "from": "next-tick@0.1.x",
+                  "from": "next-tick@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
                 }
               }
@@ -669,49 +681,49 @@
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@^0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@^0.2.0",
+          "from": "text-table@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
     "jshint": {
       "version": "2.5.11",
-      "from": "jshint@2.5.x",
+      "from": "jshint@>=2.5.0 <2.6.0",
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
       "dependencies": {
         "cli": {
-          "version": "0.6.5",
-          "from": "cli@0.6.x",
-          "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
+          "version": "0.6.6",
+          "from": "cli@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~ 3.2.1",
+              "from": "glob@>=3.2.1 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -722,44 +734,49 @@
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "console-browserify@1.1.x",
+          "from": "console-browserify@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "date-now@^0.1.4",
+              "from": "date-now@>=0.1.4 <0.2.0",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@0.1.x",
+          "from": "exit@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "htmlparser2": {
           "version": "3.8.2",
-          "from": "htmlparser2@3.8.x",
+          "from": "htmlparser2@>=3.8.0 <3.9.0",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
           "dependencies": {
             "domhandler": {
               "version": "2.3.0",
-              "from": "domhandler@2.3",
+              "from": "domhandler@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
             },
             "domutils": {
               "version": "1.5.1",
-              "from": "domutils@1.5",
+              "from": "domutils@>=1.5.0 <1.6.0",
               "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
               "dependencies": {
                 "dom-serializer": {
-                  "version": "0.0.1",
-                  "from": "dom-serializer@0",
-                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.0.1.tgz",
+                  "version": "0.1.0",
+                  "from": "dom-serializer@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                   "dependencies": {
+                    "domelementtype": {
+                      "version": "1.1.3",
+                      "from": "domelementtype@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                    },
                     "entities": {
                       "version": "1.1.1",
-                      "from": "entities@~1.1.1",
+                      "from": "entities@>=1.1.1 <1.2.0",
                       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                     }
                   }
@@ -767,18 +784,18 @@
               }
             },
             "domelementtype": {
-              "version": "1.1.3",
-              "from": "domelementtype@1",
-              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+              "version": "1.3.0",
+              "from": "domelementtype@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@1.1",
+              "from": "readable-stream@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
@@ -788,53 +805,53 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "entities": {
               "version": "1.0.0",
-              "from": "entities@1.0",
+              "from": "entities@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
             }
           }
         },
         "minimatch": {
           "version": "1.0.0",
-          "from": "minimatch@1.0.x",
+          "from": "minimatch@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@~1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "shelljs": {
           "version": "0.3.0",
-          "from": "shelljs@0.3.x",
+          "from": "shelljs@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
         },
         "strip-json-comments": {
           "version": "1.0.2",
-          "from": "strip-json-comments@1.0.x",
+          "from": "strip-json-comments@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
         },
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@1.6.x",
+          "from": "underscore@>=1.6.0 <1.7.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
         }
       }
@@ -846,59 +863,234 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@^0.5.1",
+          "from": "chalk@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "log-symbols": {
-          "version": "1.0.1",
-          "from": "log-symbols@^1.0.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.1.tgz"
+          "version": "1.0.2",
+          "from": "log-symbols@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@>=1.0.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.1",
+                  "from": "supports-color@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                }
+              }
+            }
+          }
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@^0.2.0",
+          "from": "text-table@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+        }
+      }
+    },
+    "load-grunt-tasks": {
+      "version": "3.1.0",
+      "from": "load-grunt-tasks@3.1.0",
+      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.1.0.tgz",
+      "dependencies": {
+        "findup-sync": {
+          "version": "0.2.1",
+          "from": "findup-sync@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "4.3.5",
+              "from": "glob@>=4.3.0 <4.4.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.4",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "multimatch": {
+          "version": "2.0.0",
+          "from": "multimatch@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-union": {
+              "version": "1.0.1",
+              "from": "array-union@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+              "dependencies": {
+                "array-uniq": {
+                  "version": "1.0.2",
+                  "from": "array-uniq@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.4",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -909,18 +1101,18 @@
       "dependencies": {
         "hashring": {
           "version": "0.0.8",
-          "from": "hashring@0.0.x",
+          "from": "hashring@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/hashring/-/hashring-0.0.8.tgz",
           "dependencies": {
             "bisection": {
               "version": "0.0.3",
-              "from": "bisection@",
+              "from": "bisection@*",
               "resolved": "https://registry.npmjs.org/bisection/-/bisection-0.0.3.tgz"
             },
             "simple-lru-cache": {
-              "version": "0.0.1",
-              "from": "simple-lru-cache@0.0.x",
-              "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.1.tgz"
+              "version": "0.0.2",
+              "from": "simple-lru-cache@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz"
             }
           }
         },
@@ -945,28 +1137,28 @@
       "dependencies": {
         "qs": {
           "version": "1.0.2",
-          "from": "qs@~1.0.0",
+          "from": "qs@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.0",
-          "from": "json-stringify-safe@~5.0.0",
+          "from": "json-stringify-safe@>=5.0.0 <5.1.0",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
         },
         "mime-types": {
           "version": "1.0.2",
-          "from": "mime-types@~1.0.1",
+          "from": "mime-types@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
-          "from": "forever-agent@~0.5.0",
+          "from": "forever-agent@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "node-uuid": {
-          "version": "1.4.2",
-          "from": "node-uuid@~1.4.0",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+          "version": "1.4.3",
+          "from": "node-uuid@>=1.4.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
         },
         "tough-cookie": {
           "version": "0.12.1",
@@ -982,12 +1174,12 @@
         },
         "form-data": {
           "version": "0.1.4",
-          "from": "form-data@~0.1.0",
+          "from": "form-data@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
           "dependencies": {
             "combined-stream": {
               "version": "0.0.7",
-              "from": "combined-stream@~0.0.4",
+              "from": "combined-stream@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
@@ -999,29 +1191,29 @@
             },
             "mime": {
               "version": "1.2.11",
-              "from": "mime@~1.2.11",
+              "from": "mime@>=1.2.11 <1.3.0",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "async": {
               "version": "0.9.0",
-              "from": "async@~0.9.0",
+              "from": "async@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             }
           }
         },
         "tunnel-agent": {
           "version": "0.4.0",
-          "from": "tunnel-agent@~0.4.0",
+          "from": "tunnel-agent@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
         },
         "http-signature": {
           "version": "0.10.1",
-          "from": "http-signature@~0.10.0",
+          "from": "http-signature@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "assert-plus@^0.1.5",
+              "from": "assert-plus@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "asn1": {
@@ -1038,7 +1230,7 @@
         },
         "oauth-sign": {
           "version": "0.3.0",
-          "from": "oauth-sign@~0.3.0",
+          "from": "oauth-sign@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
         },
         "hawk": {
@@ -1048,34 +1240,34 @@
           "dependencies": {
             "hoek": {
               "version": "0.9.1",
-              "from": "hoek@0.9.x",
+              "from": "hoek@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
             },
             "boom": {
               "version": "0.4.2",
-              "from": "boom@0.4.x",
+              "from": "boom@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
             },
             "cryptiles": {
               "version": "0.2.2",
-              "from": "cryptiles@0.2.x",
+              "from": "cryptiles@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
             },
             "sntp": {
               "version": "0.2.4",
-              "from": "sntp@0.2.x",
+              "from": "sntp@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
             }
           }
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "from": "aws-sign2@~0.5.0",
+          "from": "aws-sign2@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         },
         "stringstream": {
           "version": "0.0.4",
-          "from": "stringstream@~0.0.4",
+          "from": "stringstream@>=0.0.4 <0.1.0",
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
         }
       }
@@ -1087,24 +1279,24 @@
       "dependencies": {
         "assert-plus": {
           "version": "0.1.5",
-          "from": "assert-plus@^0.1.5",
+          "from": "assert-plus@>=0.1.5 <0.2.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
         },
         "backoff": {
           "version": "2.4.1",
-          "from": "backoff@^2.3.0",
+          "from": "backoff@>=2.3.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
           "dependencies": {
             "precond": {
               "version": "0.2.3",
-              "from": "precond@0.2",
+              "from": "precond@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
             }
           }
         },
         "csv": {
           "version": "0.4.1",
-          "from": "csv@^0.4.0",
+          "from": "csv@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.1.tgz",
           "dependencies": {
             "csv-generate": {
@@ -1113,14 +1305,14 @@
               "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.4.tgz"
             },
             "csv-parse": {
-              "version": "0.0.6",
+              "version": "0.1.0",
               "from": "csv-parse@*",
-              "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.0.6.tgz"
+              "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.0.tgz"
             },
             "stream-transform": {
-              "version": "0.0.6",
+              "version": "0.0.7",
               "from": "stream-transform@*",
-              "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.0.6.tgz"
+              "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.0.7.tgz"
             },
             "csv-stringify": {
               "version": "0.0.6",
@@ -1131,22 +1323,22 @@
         },
         "deep-equal": {
           "version": "0.2.2",
-          "from": "deep-equal@^0.2.1",
+          "from": "deep-equal@>=0.2.1 <0.3.0",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
         },
         "escape-regexp-component": {
           "version": "1.0.2",
-          "from": "escape-regexp-component@^1.0.2",
+          "from": "escape-regexp-component@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
         },
         "formidable": {
-          "version": "1.0.16",
-          "from": "formidable@^1.0.14",
-          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.16.tgz"
+          "version": "1.0.17",
+          "from": "formidable@>=1.0.14 <2.0.0",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
         },
         "http-signature": {
           "version": "0.10.1",
-          "from": "http-signature@^0.10.0",
+          "from": "http-signature@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
           "dependencies": {
             "asn1": {
@@ -1163,64 +1355,64 @@
         },
         "keep-alive-agent": {
           "version": "0.0.1",
-          "from": "keep-alive-agent@^0.0.1",
+          "from": "keep-alive-agent@>=0.0.1 <0.0.2",
           "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
         },
         "lru-cache": {
           "version": "2.5.0",
-          "from": "lru-cache@^2.5.0",
+          "from": "lru-cache@>=2.5.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
         },
         "mime": {
           "version": "1.3.4",
-          "from": "mime@^1.2.11",
+          "from": "mime@>=1.2.11 <2.0.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         },
         "negotiator": {
           "version": "0.4.9",
-          "from": "negotiator@^0.4.5",
+          "from": "negotiator@>=0.4.5 <0.5.0",
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
         },
         "node-uuid": {
-          "version": "1.4.2",
-          "from": "node-uuid@^1.4.1",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+          "version": "1.4.3",
+          "from": "node-uuid@>=1.4.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
         },
         "once": {
           "version": "1.3.1",
-          "from": "once@^1.3.0",
+          "from": "once@>=1.3.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
           "dependencies": {
             "wrappy": {
               "version": "1.0.1",
-              "from": "wrappy@1",
+              "from": "wrappy@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
             }
           }
         },
         "qs": {
           "version": "1.2.2",
-          "from": "qs@^1.0.0",
+          "from": "qs@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
         },
         "semver": {
           "version": "2.3.2",
-          "from": "semver@^2.3.0",
+          "from": "semver@>=2.3.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
         },
         "spdy": {
-          "version": "1.30.1",
-          "from": "spdy@^1.26.5",
-          "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.30.1.tgz"
+          "version": "1.31.0",
+          "from": "spdy@>=1.26.5 <2.0.0",
+          "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.31.0.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.0",
-          "from": "tunnel-agent@^0.4.0",
+          "from": "tunnel-agent@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
         },
         "verror": {
           "version": "1.6.0",
-          "from": "verror@^1.4.0",
+          "from": "verror@>=1.4.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
           "dependencies": {
             "extsprintf": {
@@ -1232,7 +1424,7 @@
         },
         "dtrace-provider": {
           "version": "0.2.8",
-          "from": "dtrace-provider@^0.2.8",
+          "from": "dtrace-provider@>=0.2.8 <0.3.0",
           "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
         }
       }
@@ -1244,59 +1436,59 @@
       "dependencies": {
         "buffer-equal": {
           "version": "0.0.1",
-          "from": "buffer-equal@~0.0.0",
+          "from": "buffer-equal@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
         },
         "deep-equal": {
           "version": "0.0.0",
-          "from": "deep-equal@~0.0.0",
+          "from": "deep-equal@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
         },
         "difflet": {
           "version": "0.2.6",
-          "from": "difflet@~0.2.0",
+          "from": "difflet@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
           "dependencies": {
             "traverse": {
               "version": "0.6.6",
-              "from": "traverse@0.6.x",
+              "from": "traverse@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
             },
             "charm": {
               "version": "0.1.2",
-              "from": "charm@0.1.x",
+              "from": "charm@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
             },
             "deep-is": {
               "version": "0.1.3",
-              "from": "deep-is@0.1.x",
+              "from": "deep-is@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             }
           }
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@~3.2.1",
+          "from": "glob@>=3.2.1 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@0.3",
+              "from": "minimatch@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -1309,7 +1501,7 @@
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "mkdirp@~0.3 || 0.4 || 0.5",
+          "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
@@ -1321,39 +1513,39 @@
         },
         "nopt": {
           "version": "2.2.1",
-          "from": "nopt@~2",
+          "from": "nopt@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@1",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "runforcover": {
           "version": "0.0.2",
-          "from": "runforcover@~0.0.2",
+          "from": "runforcover@>=0.0.2 <0.1.0",
           "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
           "dependencies": {
             "bunker": {
               "version": "0.1.2",
-              "from": "bunker@0.1.X",
+              "from": "bunker@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
               "dependencies": {
                 "burrito": {
                   "version": "0.2.12",
-                  "from": "burrito@>=0.2.5 <0.3",
+                  "from": "burrito@>=0.2.5 <0.3.0",
                   "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                   "dependencies": {
                     "traverse": {
                       "version": "0.5.2",
-                      "from": "traverse@~0.5.1",
+                      "from": "traverse@>=0.5.1 <0.6.0",
                       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
                     },
                     "uglify-js": {
                       "version": "1.1.1",
-                      "from": "uglify-js@~1.1.1",
+                      "from": "uglify-js@>=1.1.1 <1.2.0",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
                     }
                   }
@@ -1370,17 +1562,46 @@
         "yamlish": {
           "version": "0.0.5",
           "from": "yamlish@*"
+        },
+        "tap-consumer": {
+          "version": "0.0.1",
+          "from": "tap-consumer@*",
+          "resolved": "https://registry.npmjs.org/tap-consumer/-/tap-consumer-0.0.1.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "tap-results": {
+              "version": "0.0.2",
+              "from": "tap-results@>=0.0.0 <1.0.0",
+              "resolved": "https://registry.npmjs.org/tap-results/-/tap-results-0.0.2.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "1.0.0",
+                  "from": "inherits@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                }
+              }
+            },
+            "yamlish": {
+              "version": "0.0.6",
+              "from": "yamlish@*",
+              "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz"
+            }
+          }
         }
       }
     },
     "walk": {
       "version": "2.3.9",
-      "from": "walk@2.3.x",
+      "from": "walk@>=2.3.0 <2.4.0",
       "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz",
       "dependencies": {
         "foreachasync": {
           "version": "3.0.0",
-          "from": "foreachasync@^3.0.0",
+          "from": "foreachasync@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
   "devDependencies": {
     "ass": "0.0.4",
     "grunt": "0.4.5",
+    "grunt-bump": "0.3.0",
     "grunt-cli": "0.1.13",
     "grunt-contrib-jshint": "0.10.0",
     "grunt-copyright": "0.1.0",
     "grunt-nsp-shrinkwrap": "0.0.3",
     "jshint": "2.5.x",
     "jshint-stylish": "0.4.0",
+    "load-grunt-tasks": "3.1.0",
     "request": "2.40.0",
     "tap": "0.4.12",
     "walk": "2.3.x"

--- a/test/remote/block_email_tests.js
+++ b/test/remote/block_email_tests.js
@@ -69,6 +69,7 @@ test(
           function (err, req, res, obj) {
             t.notOk(err, 'block request is successful')
             t.equal(res.statusCode, 200, 'block request returns a 200')
+            t.ok(obj, 'got an obj, make jshint happy')
 
             client.post('/check', { email: TEST_EMAIL, ip: TEST_IP, action: 'accountCreate' },
               function (err, req, res, obj) {

--- a/test/remote/block_ip_tests.js
+++ b/test/remote/block_ip_tests.js
@@ -69,6 +69,7 @@ test(
           function (err, req, res, obj) {
             t.notOk(err, 'block request is successful')
             t.equal(res.statusCode, 200, 'block request returns a 200')
+            t.ok(obj, 'got an obj, make jshint happy')
 
             client.post('/check', { email: TEST_EMAIL, ip: TEST_IP, action: 'accountLogin' },
               function (err, req, res, obj) {

--- a/test/remote/check_tests.js
+++ b/test/remote/check_tests.js
@@ -38,6 +38,7 @@ var client = restify.createJsonClient({
         function (err, req, res, obj) {
           t.notOk(err, 'good request is successful')
           t.equal(res.statusCode, 200, 'good request returns a 200')
+          t.ok(obj, 'got an obj, make jshint happy')
           t.end()
         }
       )

--- a/test/remote/email_normalization.js
+++ b/test/remote/email_normalization.js
@@ -50,14 +50,17 @@ test(
     client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: TEST_IP },
       function (err, req, res, obj) {
         t.equal(res.statusCode, 200, 'first login attempt noted')
+        t.ok(obj, 'got an obj, make jshint happy')
 
         client.post('/failedLoginAttempt', { email: 'TEST@example.com', ip: TEST_IP },
           function (err, req, res, obj) {
             t.equal(res.statusCode, 200, 'second login attempt noted')
+            t.ok(obj, 'got an obj, make jshint happy')
 
             client.post('/failedLoginAttempt', { email: 'test@Example.Com', ip: TEST_IP },
               function (err, req, res, obj) {
                 t.equal(res.statusCode, 200, 'third login attempt noted')
+                t.ok(obj, 'got an obj, make jshint happy')
 
                 client.post('/check', { email: TEST_EMAIL, ip: TEST_IP, action: 'accountLogin' },
                   function (err, req, res, obj) {
@@ -89,6 +92,7 @@ test(
       function (err, req, res, obj) {
         t.notOk(err, 'request is successful')
         t.equal(res.statusCode, 200, 'request returns a 200')
+        t.ok(obj, 'got an obj, make jshint happy')
 
         client.post('/check', { email: TEST_EMAIL, ip: TEST_IP, action: 'accountLogin' },
           function (err, req, res, obj) {
@@ -109,6 +113,7 @@ test(
       function (err, req, res, obj) {
         t.notOk(err, 'block request is successful')
         t.equal(res.statusCode, 200, 'block request returns a 200')
+        t.ok(obj, 'got an obj, make jshint happy')
 
         client.post('/check', { email: TEST_EMAIL, ip: TEST_IP, action: 'accountCreate' },
           function (err, req, res, obj) {

--- a/test/remote/failed_login_attempt_tests.js
+++ b/test/remote/failed_login_attempt_tests.js
@@ -37,6 +37,7 @@ test(
       function (err, req, res, obj) {
         t.notOk(err, 'good request is successful')
         t.equal(res.statusCode, 200, 'good request returns a 200')
+        t.ok(obj, 'got an obj, make jshint happy')
         t.end()
       }
     )

--- a/test/remote/never_blocked.js
+++ b/test/remote/never_blocked.js
@@ -83,10 +83,12 @@ test(
     client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: TEST_IP },
       function (err, req, res, obj) {
         t.equal(res.statusCode, 200, 'first login attempt noted')
+        t.ok(obj, 'got an obj, make jshint happy')
 
         client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: TEST_IP },
           function (err, req, res, obj) {
             t.equal(res.statusCode, 200, 'second login attempt noted')
+            t.ok(obj, 'got an obj, make jshint happy')
 
             mcHelper.badLoginCheck(
               function (isOverBadLogins, isWayOverBadLogins) {

--- a/test/remote/password_reset_clears_bad_logins.js
+++ b/test/remote/password_reset_clears_bad_logins.js
@@ -50,14 +50,17 @@ test(
     client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: TEST_IP },
       function (err, req, res, obj) {
         t.equal(res.statusCode, 200, 'first login attempt noted')
+        t.ok(obj, 'got an obj, make jshint happy')
 
         client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: TEST_IP },
           function (err, req, res, obj) {
             t.equal(res.statusCode, 200, 'second login attempt noted')
+            t.ok(obj, 'got an obj, make jshint happy')
 
             client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: TEST_IP },
               function (err, req, res, obj) {
                 t.equal(res.statusCode, 200, 'third login attempt noted')
+                t.ok(obj, 'got an obj, make jshint happy')
 
                 client.post('/check', { email: TEST_EMAIL, ip: TEST_IP, action: 'accountLogin' },
                   function (err, req, res, obj) {
@@ -82,6 +85,7 @@ test(
       function (err, req, res, obj) {
         t.notOk(err, 'request is successful')
         t.equal(res.statusCode, 200, 'request returns a 200')
+        t.ok(obj, 'got an obj, make jshint happy')
 
         client.post('/check', { email: TEST_EMAIL, ip: TEST_IP, action: 'accountLogin' },
           function (err, req, res, obj) {

--- a/test/remote/password_reset_tests.js
+++ b/test/remote/password_reset_tests.js
@@ -36,6 +36,7 @@ test(
       function (err, req, res, obj) {
         t.notOk(err, 'good request is successful')
         t.equal(res.statusCode, 200, 'good request returns a 200')
+        t.ok(obj, 'got an obj, make jshint happy')
         t.end()
       }
     )


### PR DESCRIPTION
The first commit for test is to quiet a jshint warning for "'obj' is defined but never used". Previously jshint was passing since it was not linting these files. 

The second commit is just like fxa-auth-server and fxa-auth-db-mysql repos, but review the file matching patterns. r? @chilts @pdehaan 