### PR TITLE
chore(config): Update convict and switch on strict validation.

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -112,7 +112,7 @@ module.exports = function (fs, path, url, convict) {
   var files = (envConfig + ',' + process.env.CONFIG_FILES)
                 .split(',').filter(fs.existsSync)
   conf.loadFile(files)
-  conf.validate()
+  conf.validate({ strict: true })
 
   return conf
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8,31 +8,31 @@
       "resolved": "https://registry.npmjs.org/ass/-/ass-0.0.4.tgz",
       "dependencies": {
         "blanket": {
-          "version": "1.1.6",
+          "version": "1.1.7",
           "from": "blanket@>=1.1.5 <1.2.0",
-          "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.7.tgz",
           "dependencies": {
             "esprima": {
-              "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+              "version": "1.2.5",
+              "from": "esprima@>=1.2.2 <1.3.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
             },
             "falafel": {
-              "version": "0.1.6",
-              "from": "falafel@>=0.1.6 <0.2.0",
-              "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
-            },
-            "xtend": {
-              "version": "2.1.2",
-              "from": "xtend@>=2.1.1 <2.2.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+              "version": "0.3.1",
+              "from": "falafel@>=0.3.1 <0.4.0",
+              "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.3.1.tgz",
               "dependencies": {
-                "object-keys": {
-                  "version": "0.4.0",
-                  "from": "object-keys@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                "esprima": {
+                  "version": "1.1.0-dev",
+                  "from": "git://github.com/substack/esprima#is-keyword",
+                  "resolved": "git://github.com/substack/esprima#0a7f8489a11b44b019ce168506f535f22d0be290"
                 }
               }
+            },
+            "xtend": {
+              "version": "3.0.0",
+              "from": "xtend@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
             }
           }
         },
@@ -48,7 +48,7 @@
               "dependencies": {
                 "graceful-fs": {
                   "version": "1.2.3",
-                  "from": "graceful-fs@>=1.0.0 <2.0.0",
+                  "from": "graceful-fs@>=1.2.0 <1.3.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                 }
               }
@@ -219,9 +219,9 @@
           "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
           "dependencies": {
             "mkdirp": {
-              "version": "0.5.0",
+              "version": "0.5.1",
               "from": "mkdirp@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
@@ -250,9 +250,9 @@
       }
     },
     "convict": {
-      "version": "0.6.1",
-      "from": "convict@0.6.1",
-      "resolved": "https://registry.npmjs.org/convict/-/convict-0.6.1.tgz",
+      "version": "0.8.0",
+      "from": "convict@0.8.0",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-0.8.0.tgz",
       "dependencies": {
         "cjson": {
           "version": "0.3.0",
@@ -313,9 +313,9 @@
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
         },
         "moment": {
-          "version": "2.8.4",
-          "from": "moment@2.8.4",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
+          "version": "2.9.0",
+          "from": "moment@2.9.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
         },
         "optimist": {
           "version": "0.6.1",
@@ -323,9 +323,9 @@
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
-              "version": "0.0.2",
+              "version": "0.0.3",
               "from": "wordwrap@>=0.0.2 <0.1.0",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
@@ -335,9 +335,33 @@
           }
         },
         "validator": {
-          "version": "3.26.0",
-          "from": "validator@3.26.0",
-          "resolved": "https://registry.npmjs.org/validator/-/validator-3.26.0.tgz"
+          "version": "3.33.0",
+          "from": "validator@3.33.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-3.33.0.tgz"
+        },
+        "varify": {
+          "version": "0.1.1",
+          "from": "varify@0.1.1",
+          "resolved": "https://registry.npmjs.org/varify/-/varify-0.1.1.tgz",
+          "dependencies": {
+            "through": {
+              "version": "2.3.7",
+              "from": "through@>=2.3.4 <2.4.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+            },
+            "redeyed": {
+              "version": "0.4.4",
+              "from": "redeyed@>=0.4.2 <0.5.0",
+              "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+              "dependencies": {
+                "esprima": {
+                  "version": "1.0.4",
+                  "from": "esprima@>=1.0.4 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -378,7 +402,7 @@
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.1 <3.3.0",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
@@ -392,23 +416,23 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.5.0",
+                      "version": "2.6.4",
                       "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                     },
                     "sigmund": {
-                      "version": "1.0.0",
+                      "version": "1.0.1",
                       "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 }
               }
             },
             "lodash": {
-              "version": "2.4.1",
+              "version": "2.4.2",
               "from": "lodash@>=2.4.1 <2.5.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
@@ -445,14 +469,14 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.5.0",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+              "version": "2.6.4",
+              "from": "lru-cache@>=2.5.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
             },
             "sigmund": {
-              "version": "1.0.0",
+              "version": "1.0.1",
               "from": "sigmund@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
@@ -462,9 +486,9 @@
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
-              "version": "1.0.5",
+              "version": "1.0.7",
               "from": "abbrev@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             }
           }
         },
@@ -519,7 +543,7 @@
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@>=0.1.0 <0.2.0",
+          "from": "exit@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
@@ -533,14 +557,19 @@
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
-          "version": "0.1.1",
+          "version": "0.1.2",
           "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
           "dependencies": {
+            "grunt-legacy-log-utils": {
+              "version": "0.1.1",
+              "from": "grunt-legacy-log-utils@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
+            },
             "lodash": {
-              "version": "2.4.1",
+              "version": "2.4.2",
               "from": "lodash@>=2.4.1 <2.5.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
@@ -574,15 +603,15 @@
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
-              "version": "1.0.5",
+              "version": "1.0.7",
               "from": "abbrev@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             }
           }
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@>=0.1.2 <0.2.0",
+          "from": "findup-sync@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
@@ -601,23 +630,23 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.5.0",
+                      "version": "2.6.4",
                       "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                     },
                     "sigmund": {
-                      "version": "1.0.0",
+                      "version": "1.0.1",
                       "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 }
               }
             },
             "lodash": {
-              "version": "2.4.1",
+              "version": "2.4.2",
               "from": "lodash@>=2.4.1 <2.5.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
@@ -717,14 +746,14 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.5.0",
+                      "version": "2.6.4",
                       "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                     },
                     "sigmund": {
-                      "version": "1.0.0",
+                      "version": "1.0.1",
                       "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 }
@@ -746,13 +775,13 @@
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@>=0.1.0 <0.2.0",
+          "from": "exit@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "htmlparser2": {
-          "version": "3.8.2",
+          "version": "3.8.3",
           "from": "htmlparser2@>=3.8.0 <3.9.0",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "dependencies": {
             "domhandler": {
               "version": "2.3.0",
@@ -828,14 +857,14 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.5.0",
+              "version": "2.6.4",
               "from": "lru-cache@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
             },
             "sigmund": {
-              "version": "1.0.0",
+              "version": "1.0.1",
               "from": "sigmund@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
@@ -873,7 +902,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
@@ -883,7 +912,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -895,7 +924,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -924,7 +953,7 @@
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
@@ -934,7 +963,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     },
                     "get-stdin": {
@@ -951,7 +980,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
@@ -1005,9 +1034,9 @@
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
-                  "version": "2.0.4",
+                  "version": "2.0.8",
                   "from": "minimatch@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
@@ -1029,9 +1058,9 @@
                   }
                 },
                 "once": {
-                  "version": "1.3.1",
+                  "version": "1.3.2",
                   "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
@@ -1067,9 +1096,9 @@
               }
             },
             "minimatch": {
-              "version": "2.0.4",
+              "version": "2.0.8",
               "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
@@ -1141,9 +1170,9 @@
           "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz"
         },
         "json-stringify-safe": {
-          "version": "5.0.0",
+          "version": "5.0.1",
           "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
           "version": "1.0.2",
@@ -1157,20 +1186,13 @@
         },
         "node-uuid": {
           "version": "1.4.3",
-          "from": "node-uuid@>=1.4.1 <2.0.0",
+          "from": "node-uuid@>=1.4.0 <1.5.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
         },
         "tough-cookie": {
-          "version": "0.12.1",
+          "version": "1.2.0",
           "from": "tough-cookie@>=0.12.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
-          "dependencies": {
-            "punycode": {
-              "version": "1.3.2",
-              "from": "punycode@>=0.2.0",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-            }
-          }
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.2.0.tgz"
         },
         "form-data": {
           "version": "0.1.4",
@@ -1195,9 +1217,9 @@
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "async": {
-              "version": "0.9.0",
+              "version": "0.9.2",
               "from": "async@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
             }
           }
         },
@@ -1295,29 +1317,29 @@
           }
         },
         "csv": {
-          "version": "0.4.1",
+          "version": "0.4.4",
           "from": "csv@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.4.tgz",
           "dependencies": {
             "csv-generate": {
-              "version": "0.0.4",
-              "from": "csv-generate@*",
-              "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.4.tgz"
+              "version": "0.0.6",
+              "from": "csv-generate@>=0.0.6 <0.0.7",
+              "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.6.tgz"
             },
             "csv-parse": {
-              "version": "0.1.0",
-              "from": "csv-parse@*",
-              "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.0.tgz"
+              "version": "0.1.3",
+              "from": "csv-parse@>=0.1.3 <0.2.0",
+              "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.3.tgz"
             },
             "stream-transform": {
-              "version": "0.0.7",
-              "from": "stream-transform@*",
-              "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.0.7.tgz"
+              "version": "0.0.9",
+              "from": "stream-transform@>=0.0.9 <0.0.10",
+              "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.0.9.tgz"
             },
             "csv-stringify": {
-              "version": "0.0.6",
-              "from": "csv-stringify@*",
-              "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.6.tgz"
+              "version": "0.0.8",
+              "from": "csv-stringify@>=0.0.8 <0.0.9",
+              "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.8.tgz"
             }
           }
         },
@@ -1359,9 +1381,9 @@
           "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
         },
         "lru-cache": {
-          "version": "2.5.0",
+          "version": "2.6.4",
           "from": "lru-cache@>=2.5.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
         },
         "mime": {
           "version": "1.3.4",
@@ -1375,13 +1397,13 @@
         },
         "node-uuid": {
           "version": "1.4.3",
-          "from": "node-uuid@>=1.4.1 <2.0.0",
+          "from": "node-uuid@>=1.4.0 <1.5.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
         },
         "once": {
-          "version": "1.3.1",
+          "version": "1.3.2",
           "from": "once@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
           "dependencies": {
             "wrappy": {
               "version": "1.0.1",
@@ -1401,9 +1423,9 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
         },
         "spdy": {
-          "version": "1.31.0",
+          "version": "1.32.0",
           "from": "spdy@>=1.26.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.31.0.tgz"
+          "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.32.0.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.0",
@@ -1471,25 +1493,20 @@
           "from": "glob@>=3.2.1 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
             "minimatch": {
               "version": "0.3.0",
               "from": "minimatch@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.5.0",
+                  "version": "2.6.4",
                   "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                 },
                 "sigmund": {
-                  "version": "1.0.0",
+                  "version": "1.0.1",
                   "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             }
@@ -1500,9 +1517,9 @@
           "from": "inherits@*"
         },
         "mkdirp": {
-          "version": "0.5.0",
+          "version": "0.5.1",
           "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
@@ -1517,9 +1534,9 @@
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
           "dependencies": {
             "abbrev": {
-              "version": "1.0.5",
+              "version": "1.0.7",
               "from": "abbrev@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             }
           }
         },
@@ -1568,11 +1585,6 @@
           "from": "tap-consumer@*",
           "resolved": "https://registry.npmjs.org/tap-consumer/-/tap-consumer-0.0.1.tgz",
           "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
             "tap-results": {
               "version": "0.0.2",
               "from": "tap-results@>=0.0.0 <1.0.0",
@@ -1584,11 +1596,6 @@
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                 }
               }
-            },
-            "yamlish": {
-              "version": "0.0.6",
-              "from": "yamlish@*",
-              "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz"
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "aws-sdk": "2.0.0-rc.20",
     "bluebird": "1.2.2",
     "bunyan": "0.23.1",
-    "convict": "0.6.1",
+    "convict": "0.8.0",
     "memcached": "0.2.8",
     "restify": "2.8.2"
   },


### PR DESCRIPTION
Fixes #84.

There's some dependency problem with restify and I didn't want to try to debug an upgrade to the new release, which is a major API version bump.  So I added a `--force` to the dependency checker.