### PR TITLE
chore(shrinkwrap): update ass to what other modules use; update shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,130 +1,84 @@
 {
   "name": "fxa-customs-server",
-  "version": "0.36.0",
+  "version": "0.39.0",
   "dependencies": {
     "ass": {
-      "version": "0.0.4",
-      "from": "ass@0.0.4",
-      "resolved": "https://registry.npmjs.org/ass/-/ass-0.0.4.tgz",
+      "version": "1.0.0",
+      "from": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
+      "resolved": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
       "dependencies": {
+        "async": {
+          "version": "0.9.0",
+          "from": "async@0.9.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+        },
         "blanket": {
-          "version": "1.1.7",
-          "from": "blanket@>=1.1.5 <1.2.0",
-          "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.7.tgz",
+          "version": "1.1.6",
+          "from": "blanket@1.1.6",
+          "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
           "dependencies": {
             "esprima": {
-              "version": "1.2.5",
-              "from": "esprima@>=1.2.2 <1.3.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+              "version": "1.0.4",
+              "from": "esprima@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             },
             "falafel": {
-              "version": "0.3.1",
-              "from": "falafel@>=0.3.1 <0.4.0",
-              "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.3.1.tgz",
-              "dependencies": {
-                "esprima": {
-                  "version": "1.1.0-dev",
-                  "from": "git://github.com/substack/esprima#is-keyword",
-                  "resolved": "git://github.com/substack/esprima#0a7f8489a11b44b019ce168506f535f22d0be290"
-                }
-              }
+              "version": "0.1.6",
+              "from": "falafel@>=0.1.6 <0.2.0",
+              "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
             },
             "xtend": {
-              "version": "3.0.0",
-              "from": "xtend@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
-            }
-          }
-        },
-        "temp": {
-          "version": "0.6.0",
-          "from": "temp@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/temp/-/temp-0.6.0.tgz",
-          "dependencies": {
-            "rimraf": {
-              "version": "2.1.4",
-              "from": "rimraf@>=2.1.4 <2.2.0",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
+              "version": "2.1.2",
+              "from": "xtend@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "dependencies": {
-                "graceful-fs": {
-                  "version": "1.2.3",
-                  "from": "graceful-fs@>=1.2.0 <1.3.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                "object-keys": {
+                  "version": "0.4.0",
+                  "from": "object-keys@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                 }
               }
-            },
-            "osenv": {
-              "version": "0.0.3",
-              "from": "osenv@0.0.3",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
             }
           }
-        },
-        "async": {
-          "version": "0.2.10",
-          "from": "async@>=0.2.9 <0.3.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "cheerio": {
-          "version": "0.12.4",
-          "from": "cheerio@>=0.12.4 <0.13.0",
-          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.12.4.tgz",
+          "version": "0.14.0",
+          "from": "cheerio@0.14.0",
+          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.14.0.tgz",
           "dependencies": {
-            "cheerio-select": {
-              "version": "0.0.3",
-              "from": "cheerio-select@*",
-              "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-0.0.3.tgz",
-              "dependencies": {
-                "CSSselect": {
-                  "version": "0.7.0",
-                  "from": "CSSselect@>=0.0.0 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.7.0.tgz",
-                  "dependencies": {
-                    "CSSwhat": {
-                      "version": "0.4.7",
-                      "from": "CSSwhat@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
-                    },
-                    "domutils": {
-                      "version": "1.4.3",
-                      "from": "domutils@>=1.4.0 <1.5.0",
-                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
-                      "dependencies": {
-                        "domelementtype": {
-                          "version": "1.3.0",
-                          "from": "domelementtype@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-                        }
-                      }
-                    },
-                    "boolbase": {
-                      "version": "1.0.0",
-                      "from": "boolbase@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
-                    },
-                    "nth-check": {
-                      "version": "1.0.1",
-                      "from": "nth-check@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
             "htmlparser2": {
-              "version": "3.1.4",
-              "from": "htmlparser2@3.1.4",
-              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.1.4.tgz",
+              "version": "3.7.3",
+              "from": "htmlparser2@>=3.7.0 <3.8.0",
+              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
               "dependencies": {
                 "domhandler": {
-                  "version": "2.0.3",
-                  "from": "domhandler@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.0.3.tgz"
+                  "version": "2.2.1",
+                  "from": "domhandler@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
                 },
                 "domutils": {
-                  "version": "1.1.6",
-                  "from": "domutils@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz"
+                  "version": "1.5.1",
+                  "from": "domutils@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                  "dependencies": {
+                    "dom-serializer": {
+                      "version": "0.1.0",
+                      "from": "dom-serializer@>=0.0.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                      "dependencies": {
+                        "domelementtype": {
+                          "version": "1.1.3",
+                          "from": "domelementtype@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                        },
+                        "entities": {
+                          "version": "1.1.1",
+                          "from": "entities@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
                 },
                 "domelementtype": {
                   "version": "1.3.0",
@@ -132,9 +86,9 @@
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                 },
                 "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
@@ -160,15 +114,51 @@
                 }
               }
             },
-            "underscore": {
-              "version": "1.4.4",
-              "from": "underscore@>=1.4.0 <1.5.0",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
-            },
             "entities": {
-              "version": "0.5.0",
-              "from": "entities@>=0.0.0 <1.0.0",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz"
+              "version": "1.0.0",
+              "from": "entities@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+            },
+            "CSSselect": {
+              "version": "0.4.1",
+              "from": "CSSselect@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
+              "dependencies": {
+                "CSSwhat": {
+                  "version": "0.4.7",
+                  "from": "CSSwhat@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
+                },
+                "domutils": {
+                  "version": "1.4.3",
+                  "from": "domutils@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.3.0",
+                      "from": "domelementtype@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        },
+        "temp": {
+          "version": "0.8.1",
+          "from": "temp@0.8.1",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
+          "dependencies": {
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@>=2.2.6 <2.3.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             }
           }
         }
@@ -470,7 +460,7 @@
           "dependencies": {
             "lru-cache": {
               "version": "2.6.4",
-              "from": "lru-cache@>=2.5.0 <3.0.0",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
             },
             "sigmund": {
@@ -543,7 +533,7 @@
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@>=0.1.1 <0.2.0",
+          "from": "exit@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
@@ -611,12 +601,12 @@
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@>=0.1.0 <0.2.0",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.1 <3.3.0",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
@@ -775,7 +765,7 @@
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@>=0.1.1 <0.2.0",
+          "from": "exit@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "htmlparser2": {
@@ -902,7 +892,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
@@ -953,7 +943,7 @@
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
@@ -963,7 +953,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@>=1.0.0 <2.0.0",
+                      "from": "ansi-regex@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     },
                     "get-stdin": {
@@ -980,7 +970,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@>=1.0.0 <2.0.0",
+                      "from": "ansi-regex@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
@@ -1186,13 +1176,13 @@
         },
         "node-uuid": {
           "version": "1.4.3",
-          "from": "node-uuid@>=1.4.0 <1.5.0",
+          "from": "node-uuid@>=1.4.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
         },
         "tough-cookie": {
-          "version": "1.2.0",
+          "version": "2.0.0",
           "from": "tough-cookie@>=0.12.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
         },
         "form-data": {
           "version": "0.1.4",
@@ -1397,7 +1387,7 @@
         },
         "node-uuid": {
           "version": "1.4.3",
-          "from": "node-uuid@>=1.4.0 <1.5.0",
+          "from": "node-uuid@>=1.4.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
         },
         "once": {
@@ -1490,7 +1480,7 @@
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.1 <3.3.0",
+          "from": "glob@>=3.2.9 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "minimatch": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "restify": "2.8.2"
   },
   "devDependencies": {
-    "ass": "0.0.4",
+    "ass": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
     "grunt": "0.4.5",
     "grunt-bump": "0.3.0",
     "grunt-cli": "0.1.13",


### PR DESCRIPTION
I went to update shrinkwrap, and the version of `ass` we use causes a weird error with shrinkwrap. So use the version we use in other repos. 

@chilts r? 