### PR TITLE
chore(docs): remove misleading reference to awsbox

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -19,7 +19,6 @@ module.exports = function (fs, path, url, convict) {
     },
     publicUrl: {
       format: 'url',
-      // the real url is set by awsbox
       default: 'http://127.0.0.1:7000',
       env: 'PUBLIC_URL'
     },


### PR DESCRIPTION
Just completing cleanup of awsbox removal.