### PR TITLE
feat(api): Add account status check with rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ There are three types of policies:
 We currently have the following policies in place:
 
 * rate-limiting when too many emails (`config.limits.maxEmails` defaults to 3) have been sent to the same email address in a given time period (`config.limits.rateLimitIntervalSeconds` defaults to 15 minutes)
+* rate-limiting when too many requests to look up account status by email address (`config.limits.maxAccountStatusCheck`) have been sent from the same ip address during period (`config.limits.rateLimitIntervalSeconds` defaults to 15 minutes)
 * rate-limiting when too many failed login attempts (`config.limits.maxBadLogins` defaults to 2) have occurred for a given account and IP address, in a given time period (`config.limits.rateLimitIntervalSeconds` defaults to 15 minutes)
 * lockout when too many failed login attempts (`config.limits.badLoginLockout` defaults to 20) have occurred for a given account regardless of the IP address, in a given time period  (`config.limits.rateLimitIntervalSeconds` defaults to 15 minutes)
 * manual blocking of an account (see `/blockEmail` API call)

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -61,6 +61,12 @@ module.exports = function (fs, path, url, convict) {
         format: 'nat',
         env: 'MAX_BAD_LOGINS'
       },
+      maxAccountStatusCheck: {
+        doc: 'Number of account status checks within rateLimitIntervalSeconds before throttling',
+        default: 5,
+        format: 'nat',
+        env: 'MAX_ACCOUNT_STATUS_CHECK'
+      },
       badLoginLockout: {
         doc: 'Number failed login attempts within badLoginLockoutIntervalSeconds before locking the account',
         default: 20,

--- a/lib/email_record.js
+++ b/lib/email_record.js
@@ -11,7 +11,7 @@ module.exports = function (RATE_LIMIT_INTERVAL_MS, BLOCK_INTERVAL_MS, BAD_LOGIN_
     accountCreate            : true,
     recoveryEmailResendCode  : true,
     passwordForgotSendCode   : true,
-    passwordForgotResendCode : true,
+    passwordForgotResendCode : true
   }
 
   function isEmailSendingAction(action) {

--- a/lib/ip_record.js
+++ b/lib/ip_record.js
@@ -3,36 +3,89 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // Keep track of events related to just IP addresses
-module.exports = function (BLOCK_INTERVAL_MS, now) {
+module.exports = function (BLOCK_INTERVAL_MS, RATE_LIMIT_INTERVAL_MS, MAX_ACCOUNT_STATUS_CHECK, now) {
 
   now = now || Date.now
 
+  var ACCOUNT_STATUS_ACTION = {
+    accountStatusCheck       : true
+  }
+
   function IpRecord() {}
+
+  function isAccountStatusAction(action) {
+    return ACCOUNT_STATUS_ACTION[action]
+  }
 
   IpRecord.parse = function (object) {
     var rec = new IpRecord()
     object = object || {}
     rec.bk = object.bk // timestamp when the account was blocked
+    rec.as = object.as || []  // timestamps when account status check occurred
+    rec.rl = object.rl  // timestamp when the account was rate-limited
     return rec
   }
 
+  IpRecord.prototype.isOverAccountStatusCheck = function () {
+    return this.as.length > MAX_ACCOUNT_STATUS_CHECK
+  }
+
+  IpRecord.prototype.trimAccountStatus = function (now) {
+    if (this.as.length === 0) { return }
+    // "as" is naturally ordered from oldest to newest
+    // and we only need to keep up to MAX_ACCOUNT_STATUS_CHECK + 1
+
+    var i = this.as.length - 1
+    var n = 0
+    var hit = this.as[i]
+    while (hit > (now - RATE_LIMIT_INTERVAL_MS) && n <= MAX_ACCOUNT_STATUS_CHECK) {
+      hit = this.as[--i]
+      n++
+    }
+    this.as = this.as.slice(i + 1)
+  }
+
+  IpRecord.prototype.addAccountStatusCheck = function () {
+    this.trimAccountStatus(now())
+    this.as.push(now())
+  }
+
   IpRecord.prototype.shouldBlock = function () {
-    return this.isBlocked()
+    return this.isBlocked() || this.isRateLimited()
   }
 
   IpRecord.prototype.isBlocked = function () {
     return !!(this.bk && (now() - this.bk < BLOCK_INTERVAL_MS))
   }
 
+  IpRecord.prototype.isRateLimited = function () {
+    return !!(this.rl && (now() - this.rl < RATE_LIMIT_INTERVAL_MS))
+  }
+
   IpRecord.prototype.block = function () {
     this.bk = now()
   }
 
-  IpRecord.prototype.retryAfter = function () {
-    return Math.max(0, Math.floor(((this.bk || 0) + BLOCK_INTERVAL_MS - now()) / 1000))
+  IpRecord.prototype.rateLimit = function () {
+    this.rl = now()
+    this.as = []
   }
 
-  IpRecord.prototype.update = function () {
+  IpRecord.prototype.retryAfter = function () {
+    var rateLimitAfter = Math.floor(((this.rl || 0) + RATE_LIMIT_INTERVAL_MS - now()) / 1000)
+    var banAfter = Math.floor(((this.bk || 0) + BLOCK_INTERVAL_MS - now()) / 1000)
+    return Math.max(0, rateLimitAfter, banAfter)
+  }
+
+  IpRecord.prototype.update = function (action) {
+    // Increment account status check and throttle if needed
+    if (isAccountStatusAction(action)) {
+      this.addAccountStatusCheck()
+      if (this.isOverAccountStatusCheck() && !this.isRateLimited()){
+        this.rateLimit()
+      }
+    }
+
     return this.retryAfter()
   }
 

--- a/test/remote/too_many_account_status_check.js
+++ b/test/remote/too_many_account_status_check.js
@@ -1,0 +1,114 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+var test = require('tap').test
+var TestServer = require('../test_server')
+var Promise = require('bluebird')
+var restify = Promise.promisifyAll(require('restify'))
+var mcHelper = require('../memcache-helper')
+
+var TEST_IP = '192.0.2.1'
+var EMAIL = 'asdf@asfd.com'
+var ACCOUNT_STATUS_CHECK = 'accountStatusCheck'
+
+var config = {
+  listen: {
+    port: 7000
+  }
+}
+
+// Override limit values for testing
+process.env.MAX_ACCOUNT_STATUS_CHECK = 2
+process.env.RATE_LIMIT_INTERVAL_SECONDS = 1
+
+var testServer = new TestServer(config)
+
+var client = restify.createJsonClient({
+  url: 'http://127.0.0.1:' + config.listen.port
+})
+
+Promise.promisifyAll(client)
+
+test(
+  'startup',
+  function (t) {
+    testServer.start(function (err) {
+      t.type(testServer.server, 'object', 'test server was started')
+      t.notOk(err, 'no errors were returned')
+      t.end()
+    })
+  }
+)
+
+test(
+  'clear everything',
+  function (t) {
+    mcHelper.clearEverything(
+      function (err) {
+        t.notOk(err, 'no errors were returned')
+        t.end()
+      }
+    )
+  }
+)
+
+test(
+  '/check `accountStatusCheck`',
+  function (t) {
+
+    // Send requests until throttled
+    return client.postAsync('/check', { ip: TEST_IP, email: EMAIL, action: ACCOUNT_STATUS_CHECK })
+      .spread(function(req, res, obj){
+        t.equal(res.statusCode, 200, 'returns a 200')
+        t.equal(obj.block, false, 'not rate limited')
+        return client.postAsync('/check', { ip: TEST_IP, email: EMAIL, action: ACCOUNT_STATUS_CHECK })
+      })
+      .spread(function(req, res, obj){
+        t.equal(res.statusCode, 200, 'returns a 200')
+        t.equal(obj.block, false, 'not rate limited')
+        return client.postAsync('/check', { ip: TEST_IP, email: EMAIL, action: ACCOUNT_STATUS_CHECK })
+      })
+      .spread(function(req, res, obj){
+        t.equal(res.statusCode, 200, 'returns a 200')
+        t.equal(obj.block, true, 'rate limited')
+        t.equal(obj.retryAfter, 1, 'rate limit retry amount')
+
+        // Delay ~1s for rate limit to go away
+        return Promise.delay(1010)
+      })
+
+      // Reissue requests to verify that throttling is disabled
+      .then(function(){
+        return client.postAsync('/check', { ip: TEST_IP, email: EMAIL, action: ACCOUNT_STATUS_CHECK })
+      })
+      .spread(function(req, res, obj){
+        t.equal(res.statusCode, 200, 'returns a 200')
+        t.equal(obj.block, false, 'not rate limited')
+        return client.postAsync('/check', { ip: TEST_IP, email: EMAIL, action: ACCOUNT_STATUS_CHECK })
+      })
+      .spread(function(req, res, obj){
+        t.equal(res.statusCode, 200, 'returns a 200')
+        t.equal(obj.block, false, 'not rate limited')
+        return client.postAsync('/check', { ip: TEST_IP, email: EMAIL, action: ACCOUNT_STATUS_CHECK })
+      })
+      .spread(function(req, res, obj){
+        t.equal(res.statusCode, 200, 'returns a 200')
+        t.equal(obj.block, true, 'rate limited')
+        t.equal(obj.retryAfter, 1, 'rate limit retry amount')
+        t.end()
+      })
+      .catch(function(err){
+        t.fail(err)
+        t.end()
+      })
+  }
+)
+
+test(
+  'teardown',
+  function (t) {
+    testServer.stop()
+    t.equal(testServer.server.killed, true, 'test server has been killed')
+    t.end()
+  }
+)


### PR DESCRIPTION
This PR adds a new route to the customs server, `POST /accountStatus`. This is used to rate-limit requests by ip address, for getting an account's status. This is a dependency for https://github.com/mozilla/fxa-auth-server/pull/1184

Fixes #96 

@rfk this is what you had in mind? r?