### PR TITLE
fix(config): restore top-level "config" dir for $(NODE_ENV).json files.

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,4 @@
+
+You can put a $(NODE_ENV).json config file in this directory
+and it will be ready automatically on server start.
+

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -107,7 +107,7 @@ module.exports = function (fs, path, url, convict) {
   // files to process, which will be overlayed in order, in the CONFIG_FILES
   // environment variable. By default, the ./config/<env>.json file is loaded.
 
-  var envConfig = path.join(__dirname, conf.get('env') + '.json')
+  var envConfig = path.join(path.dirname(path.dirname(__dirname)), 'config', conf.get('env') + '.json')
   var files = (envConfig + ',' + process.env.CONFIG_FILES)
                 .split(',').filter(fs.existsSync)
   conf.loadFile(files)


### PR DESCRIPTION
This was lost in #98 and broke new fxa-dev deployments.