### PR TITLE
fix(check): Include more action names in various checks.

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -2,18 +2,34 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// Actions that, if allowed, would allow an attacker
+// to try a candidtate password against an account.
 var PASSWORD_CHECKING_ACTION = {
   accountLogin: true,
   accountDestroy: true,
   passwordChange: true,
 }
 
+// Actions that, if allowed, would allow an attacker
+// to check whether an account exists for a particular user.
+// Basically any unauthenticated endpoint that takes
+// an email address as input.
 var ACCOUNT_STATUS_ACTION = {
+  accountCreate: true,
+  accountLogin: true,
+  accountDestroy: true,
+  accountLock: true,
+  accountUnlockResendCode: true,
+  passwordChange: true,
+  passwordForgotSendCode: true,
   accountStatusCheck: true
 }
 
+// Actions that send an email, and hence might make
+// us look like spammers if abused.
 var EMAIL_SENDING_ACTION = {
   accountCreate: true,
+  accountUnlockResendCode: true,
   recoveryEmailResendCode: true,
   passwordForgotSendCode: true,
   passwordForgotResendCode: true


### PR DESCRIPTION
This ensures we treat all actions with similar affects as equivalent and rate-limit them together.  It's especially relevant for the many different ways that one can discover whether a particular account exists or not.

Note that the rate-limiting for account status check now counts the number of unique emails accessed within the rate-limiting window, not the total number of checks performed.  This should help mitigate the risk of adding all these other actions into that category.  We may still find we need to raise the limit on that though.