### PR TITLE
feat(email): Add config option to avoid blocking certain email domains

### DIFF
--- a/lib/allowed_email_domains.js
+++ b/lib/allowed_email_domains.js
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (config, mc, log) {
+
+  var pollInterval = null
+
+  function AllowedEmailDomains(domains) {
+    this.setAll(domains)
+  }
+
+  AllowedEmailDomains.prototype.isAllowed = function (email) {
+    var match = /^.+@(.+)$/.exec(email)
+    return match ? this.domains[match[1]] : false
+  }
+
+  AllowedEmailDomains.prototype.setAll = function (domains) {
+    this.domains = {}
+    for (var i = 0; i < domains.length; i++) {
+      this.domains[domains[i]] = true
+    }
+    return Object.keys(this.domains)
+  }
+
+  AllowedEmailDomains.prototype.push = function () {
+    log.info({ op: 'allowedEmailDomains.push' })
+    return mc.setAsync('allowedEmailDomains', Object.keys(this.domains), 0)
+      .then(this.refresh.bind(this))
+  }
+
+  AllowedEmailDomains.prototype.refresh = function (options) {
+    log.info({ op: 'allowedEmailDomains.refresh' })
+    var result = mc.getAsync('allowedEmailDomains').then(validate)
+
+    if (options && options.pushOnMissing) {
+      result = result.catch(this.push.bind(this))
+    }
+
+    return result.then(
+      this.setAll.bind(this),
+      function (err) {
+        log.error({ op: 'allowedEmailDomains.refresh', err: err })
+      }
+    )
+  }
+
+  AllowedEmailDomains.prototype.pollForUpdates = function () {
+    this.stopPolling()
+    pollInterval = setInterval(this.refresh.bind(this), config.updatePollIntervalSeconds * 1000)
+  }
+
+  AllowedEmailDomains.prototype.stopPolling = function () {
+    clearInterval(pollInterval)
+  }
+
+  function validate(domains) {
+    if (!Array.isArray(domains)) {
+      log.error({ op: 'allowedEmailDomains.validate.invalid', data: domains })
+      throw new Error('invalid allowedEmailDomains from memcache')
+    }
+    return domains
+  }
+
+  var allowedEmailDomains = new AllowedEmailDomains(config.allowedEmailDomains || [])
+  return allowedEmailDomains
+}

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -149,6 +149,16 @@ module.exports = function (fs, path, url, convict) {
         '63.245.214.162',
         '63.245.214.168'
       ]
+    },
+    allowedEmailDomains: {
+      doc: 'An array of email domains that will not be blocked or rate-limited.',
+      format: Array,
+      env: 'ALLOWED_EMAIL_DOMAINS',
+      // These are emails frequently used for testing purposes
+      default: [
+        'restmail.net',
+        'mockmyid.com'
+      ]
     }
   })
 

--- a/test/memcache-helper.js
+++ b/test/memcache-helper.js
@@ -44,6 +44,7 @@ var TEST_IP = '192.0.2.1'
 
 var limits = require('../lib/limits')(config, mc, console)
 var allowedIPs = require('../lib/allowed_ips')(config, mc, console)
+var allowedEmailDomains = require('../lib/allowed_email_domains')(config, mc, console)
 var EmailRecord = require('../lib/email_record')(limits)
 var IpEmailRecord = require('../lib/ip_email_record')(limits)
 var IpRecord = require('../lib/ip_record')(limits)
@@ -107,6 +108,7 @@ function clearEverything(cb) {
   P.all([
     mc.delAsync('limits'),
     mc.delAsync('allowedIPs'),
+    mc.delAsync('allowedEmailDomains'),
     mc.delAsync(TEST_EMAIL),
     mc.delAsync(TEST_IP + TEST_EMAIL),
     mc.delAsync(TEST_IP)
@@ -145,3 +147,14 @@ function setAllowedIPs(ips) {
 }
 
 module.exports.setAllowedIPs = setAllowedIPs
+
+function setAllowedEmailDomains(domains) {
+  allowedEmailDomains.setAll(domains)
+  return allowedEmailDomains.push()
+    .then(function (domains) {
+      mc.end()
+      return domains
+    })
+}
+
+module.exports.setAllowedEmailDomains = setAllowedEmailDomains

--- a/test/remote/block_email_tests.js
+++ b/test/remote/block_email_tests.js
@@ -7,6 +7,7 @@ var TestServer = require('../test_server')
 var mcHelper = require('../memcache-helper')
 
 var TEST_EMAIL = 'test@example.com'
+var ALLOWED_EMAIL = 'test@restmail.net'
 var TEST_IP = '192.0.2.1'
 
 var config = {
@@ -75,6 +76,34 @@ test(
               function (err, req, res, obj) {
                 t.equal(res.statusCode, 200, 'check worked')
                 t.equal(obj.block, true, 'request was blocked')
+                t.end()
+              }
+            )
+          }
+        )
+      }
+    )
+  }
+)
+
+test(
+  'allowed email is not blocked',
+  function (t) {
+    client.post('/check', { email: ALLOWED_EMAIL, ip: TEST_IP, action: 'accountLogin' },
+      function (err, req, res, obj) {
+        t.equal(res.statusCode, 200, 'check worked')
+        t.equal(obj.block, false, 'request was not blocked')
+
+        client.post('/blockEmail', { email: ALLOWED_EMAIL },
+          function (err, req, res, obj) {
+            t.notOk(err, 'block request is successful')
+            t.equal(res.statusCode, 200, 'block request returns a 200')
+            t.ok(obj, 'got an obj, make jshint happy')
+
+            client.post('/check', { email: ALLOWED_EMAIL, ip: TEST_IP, action: 'accountLogin' },
+              function (err, req, res, obj) {
+                t.equal(res.statusCode, 200, 'check worked')
+                t.equal(obj.block, false, 'request was still not blocked')
                 t.end()
               }
             )

--- a/test/remote/config_update_tests.js
+++ b/test/remote/config_update_tests.js
@@ -105,6 +105,34 @@ test(
 )
 
 test(
+  'change allowedEmailDomains',
+  function (t) {
+    var x = ['restmail.net']
+    return client.getAsync('/allowedEmailDomains')
+      .spread(function (req, res, obj) {
+        t.ok(Array.isArray(obj))
+        t.notDeepEqual(x, obj, 'allowedEmailDomains are different')
+        return mcHelper.setAllowedEmailDomains(x)
+      })
+      .then(function (ips) {
+        t.deepEqual(x, ips, 'helper sees the change')
+        return Promise.delay(1010)
+      })
+      .then(function() {
+        return client.getAsync('/allowedEmailDomains')
+      })
+      .spread(function (req, res, obj) {
+        t.deepEqual(x, obj, 'server sees the change')
+        t.end()
+      })
+      .catch(function (err) {
+        t.fail(err)
+        t.end()
+      })
+  }
+)
+
+test(
   'teardown',
   function (t) {
     testServer.stop()


### PR DESCRIPTION
Similar to our existing `ALLOWED_IPS` setting, this PR gives us the ability to allowlist a set of email address domains, exempting them from rate-limits and blocks.  This is likely very handy for QA, both for ourselves (where we currently have to raise rate limits in stage) and for others (e.g. https://bugzilla.mozilla.org/show_bug.cgi?id=1269425)

A couple of notes:

* The `allowed_email_domains.js` file is a copy-paste of the existing `allowed_ips.js` file; I considered a refactor to extract shared logic but decided not to invest in it at this time
* The checking of the allowlist is only done at the point where we are actually about to block an email, which means there should be no additional overhead for legitimate users

@seanmonstar r?