### PR TITLE
feat(server): Remove account lockout.

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -99,18 +99,6 @@ module.exports = function (fs, path, url, convict) {
         default: 5,
         format: 'nat',
         env: 'MAX_ACCOUNT_STATUS_CHECK'
-      },
-      badLoginLockout: {
-        doc: 'Number failed login attempts within badLoginLockoutIntervalSeconds before locking the account',
-        default: 20,
-        format: 'nat',
-        env: 'BAD_LOGIN_LOCKOUT'
-      },
-      badLoginLockoutIntervalSeconds: {
-        doc: 'Duration which a failed login attempt should be remembered towards account lockout',
-        default: 60 * 60 * 3, // three hours for now
-        format: 'nat',
-        env: 'BAD_LOGIN_LOCKOUT_INTERVAL_SECONDS'
       }
     },
     memcache: {

--- a/lib/email_record.js
+++ b/lib/email_record.js
@@ -38,11 +38,6 @@ module.exports = function (limits, now) {
     return this.xs.length > limits.maxEmails
   }
 
-  EmailRecord.prototype.isWayOverBadLogins = function () {
-    this.trimBadLogins(now())
-    return this.lf.length > limits.badLoginLockout
-  }
-
   EmailRecord.prototype.trimHits = function (now) {
     if (this.xs.length === 0) { return }
     // xs is naturally ordered from oldest to newest

--- a/lib/limits.js
+++ b/lib/limits.js
@@ -26,9 +26,6 @@ module.exports = function (config, mc, log) {
     this.ipRateLimitBanDurationSeconds = settings.ipRateLimitBanDurationSeconds
     this.ipRateLimitBanDurationMs = settings.ipRateLimitBanDurationSeconds * 1000
     this.maxAccountStatusCheck = settings.maxAccountStatusCheck
-    this.badLoginLockout = settings.badLoginLockout
-    this.badLoginLockoutIntervalSeconds = settings.badLoginLockoutIntervalSeconds
-    this.badLoginLockoutIntervalMs = settings.badLoginLockoutIntervalSeconds * 1000
     this.badLoginErrnoWeights = settings.badLoginErrnoWeights || {}
     return this
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -186,9 +186,7 @@ module.exports = function createServer(config, log) {
             return setRecords(email, ip, emailRecord, ipRecord, ipEmailRecord)
               .then(
                 function () {
-                  return {
-                    lockout: emailRecord.isWayOverBadLogins()
-                  }
+                  return {}
                 }
               )
           }

--- a/lib/server.js
+++ b/lib/server.js
@@ -180,7 +180,6 @@ module.exports = function createServer(config, log) {
       fetchRecords(email, ip)
         .spread(
           function (emailRecord, ipRecord, ipEmailRecord) {
-            emailRecord.addBadLogin()
             ipRecord.addBadLogin({ email: email, errno: errno })
             ipEmailRecord.addBadLogin()
             return setRecords(email, ip, emailRecord, ipRecord, ipEmailRecord)

--- a/test/local/email_record_tests.js
+++ b/test/local/email_record_tests.js
@@ -122,24 +122,6 @@ test(
 )
 
 test(
-  'isWayOverBadLogins works',
-  function (t) {
-    var er = simpleEmailRecord()
-
-    t.equal(er.isWayOverBadLogins(), false, 'record has never seen a bad login')
-    er.addBadLogin()
-    er.addBadLogin()
-    er.addBadLogin()
-    er.addBadLogin()
-    t.equal(er.isWayOverBadLogins(), false, 'record has not reached the bad login limit')
-    er.addBadLogin()
-    er.addBadLogin()
-    t.equal(er.isWayOverBadLogins(), true, 'record has reached the bad login limit')
-    t.end()
-  }
-)
-
-test(
   'retryAfter works',
   function (t) {
     var limits = {

--- a/test/local/email_record_tests.js
+++ b/test/local/email_record_tests.js
@@ -13,9 +13,7 @@ function simpleEmailRecord() {
   var limits = {
     rateLimitIntervalMs: 500,
     blockIntervalMs: 800,
-    badLoginLockoutIntervalMs: 1600,
-    maxEmails: 2,
-    badLoginLockout: 5
+    maxEmails: 2
   }
   return new (emailRecord(limits, now))()
 }
@@ -127,9 +125,7 @@ test(
     var limits = {
       rateLimitIntervalMs: 5000,
       blockIntervalMs: 8000,
-      badLoginLockoutIntervalMs: 16000,
-      maxEmails: 2,
-      badLoginLockout: 5
+      maxEmails: 2
     }
     var er = new (emailRecord(limits, function () {
       return 10000
@@ -176,9 +172,7 @@ test(
     var limits = {
       rateLimitIntervalMs: 50,
       blockIntervalMs: 50,
-      badLoginLockoutIntervalMs: 100,
-      maxEmails: 2,
-      badLoginLockout: 5
+      maxEmails: 2
     }
     var erCopy1 = (emailRecord(limits, now)).parse(er)
     t.equal(erCopy1.shouldBlock(), false, 'copied object is not blocked')
@@ -233,29 +227,16 @@ test(
   'getMinLifetimeMS works',
   function (t) {
     var limits = {
-      rateLimitIntervalMs: 10,
-      blockIntervalMs: 15,
-      badLoginLockoutIntervalMs: 20,
-      maxEmails: 2,
-      badLoginLockout: 5
-    }
-    var er = new (emailRecord(limits, now))()
-    t.equal(er.getMinLifetimeMS(), 20, 'lifetime >= lockout interval')
-    limits = {
       rateLimitIntervalMs: 11,
       blockIntervalMs: 21,
-      badLoginLockoutIntervalMs: 15,
-      maxEmails: 2,
-      badLoginLockout: 5
+      maxEmails: 2
     }
-    er = new (emailRecord(limits, now))()
+    var er = new (emailRecord(limits, now))()
     t.equal(er.getMinLifetimeMS(), 21, 'lifetime >= block interval')
     limits = {
       rateLimitIntervalMs: 22,
       blockIntervalMs: 15,
-      badLoginLockoutIntervalMs: 12,
-      maxEmails: 2,
-      badLoginLockout: 5
+      maxEmails: 2
     }
     er = new (emailRecord(limits, now))()
     t.equal(er.getMinLifetimeMS(), 22, 'lifetime >= rate limit internal')

--- a/test/memcache-helper.js
+++ b/test/memcache-helper.js
@@ -88,15 +88,13 @@ function badLoginCheck(cb) {
     function () {
       P.all([
         mc.getAsync(TEST_IP + TEST_EMAIL),
-        mc.getAsync(TEST_EMAIL),
         mc.getAsync(TEST_IP)
       ])
-      .spread(function (d1, d2, d3) {
+      .spread(function (d1, d2) {
         var ier = IpEmailRecord.parse(d1)
-        var er = EmailRecord.parse(d2)
-        var ir = IpRecord.parse(d3)
+        var ir = IpRecord.parse(d2)
         mc.end()
-        cb(ier.isOverBadLogins(), er.isWayOverBadLogins(), ir.isOverBadLogins())
+        cb(ier.isOverBadLogins(), false, ir.isOverBadLogins())
       })
     }
   )

--- a/test/remote/never_blocked.js
+++ b/test/remote/never_blocked.js
@@ -91,9 +91,8 @@ test(
             t.ok(obj, 'got an obj, make jshint happy')
 
             mcHelper.badLoginCheck(
-              function (isOverBadLogins, isWayOverBadLogins) {
+              function (isOverBadLogins) {
                 t.equal(isOverBadLogins, false, 'is still not over bad logins')
-                t.equal(isWayOverBadLogins, false, 'is still not locked out')
 
                 client.post('/check', { email: TEST_EMAIL, ip: TEST_IP, action: 'accountLogin' },
                   function (err, req, res, obj) {

--- a/test/remote/too_many_bad_logins.js
+++ b/test/remote/too_many_bad_logins.js
@@ -54,27 +54,22 @@ test(
     client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: TEST_IP },
       function (err, req, res, obj) {
         t.equal(res.statusCode, 200, 'first login attempt noted')
-        t.equal(obj.lockout, false, 'not locked out')
 
         client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: TEST_IP },
           function (err, req, res, obj) {
             t.equal(res.statusCode, 200, 'second login attempt noted')
-            t.equal(obj.lockout, false, 'not locked out')
 
             mcHelper.badLoginCheck(
-              function (isOverBadLogins, isWayOverBadLogins) {
+              function (isOverBadLogins) {
                 t.equal(isOverBadLogins, false, 'is not yet over bad logins')
-                t.equal(isWayOverBadLogins, false, 'is not locked out')
 
                 client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: TEST_IP },
                   function (err, req, res, obj) {
                     t.equal(res.statusCode, 200, 'third login attempt noted')
-                    t.equal(obj.lockout, false, 'not locked out')
 
                     mcHelper.badLoginCheck(
-                      function (isOverBadLogins, isWayOverBadLogins) {
+                      function (isOverBadLogins) {
                         t.equal(isOverBadLogins, true, 'is now over bad logins')
-                        t.equal(isWayOverBadLogins, false, 'is still not locked out')
                         t.end()
                       }
                     )
@@ -113,166 +108,6 @@ test(
       function (err) {
         t.notOk(err, 'no errors were returned')
         t.end()
-      }
-    )
-  }
-)
-
-test(
-  'too many failed logins from different IPs',
-  function (t) {
-    client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.10' },
-      function (err, req, res, obj) {
-        t.equal(res.statusCode, 200, 'failed login 1')
-        t.equal(obj.lockout, false, 'not locked out')
-
-        client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.11' },
-          function (err, req, res, obj) {
-            t.equal(res.statusCode, 200, 'failed login 2')
-            t.equal(obj.lockout, false, 'not locked out')
-
-            client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.12' },
-              function (err, req, res, obj) {
-                t.equal(res.statusCode, 200, 'failed login 3')
-                t.equal(obj.lockout, false, 'not locked out')
-
-                client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.13' },
-                  function (err, req, res, obj) {
-                    t.equal(res.statusCode, 200, 'failed login 4')
-                    t.equal(obj.lockout, false, 'not locked out')
-
-                    client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.14' },
-                      function (err, req, res, obj) {
-                        t.equal(res.statusCode, 200, 'failed login 5')
-                        t.equal(obj.lockout, false, 'locked out')
-
-                        client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.15' },
-                          function (err, req, res, obj) {
-                            t.equal(res.statusCode, 200, 'failed login 6')
-                            t.equal(obj.lockout, false, 'locked out')
-
-                            client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.16' },
-                              function (err, req, res, obj) {
-                                t.equal(res.statusCode, 200, 'failed login 7')
-                                t.equal(obj.lockout, false, 'not locked out')
-
-                                client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.17' },
-                                  function (err, req, res, obj) {
-                                    t.equal(res.statusCode, 200, 'failed login 8')
-                                    t.equal(obj.lockout, false, 'not locked out')
-
-                                    client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.18' },
-                                      function (err, req, res, obj) {
-                                        t.equal(res.statusCode, 200, 'failed login 9')
-                                        t.equal(obj.lockout, false, 'not locked out')
-
-                                        client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.19' },
-                                          function (err, req, res, obj) {
-                                            t.equal(res.statusCode, 200, 'failed login 10')
-                                            t.equal(obj.lockout, false, 'not locked out')
-
-                                            client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.20' },
-                                              function (err, req, res, obj) {
-                                                t.equal(res.statusCode, 200, 'failed login 11')
-                                                t.equal(obj.lockout, false, 'locked out')
-
-                                                client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.21' },
-                                                  function (err, req, res, obj) {
-                                                    t.equal(res.statusCode, 200, 'failed login 12')
-                                                    t.equal(obj.lockout, false, 'locked out')
-
-                                                    client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.22' },
-                                                      function (err, req, res, obj) {
-                                                        t.equal(res.statusCode, 200, 'failed login 13')
-                                                        t.equal(obj.lockout, false, 'locked out')
-
-                                                        client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.23' },
-                                                          function (err, req, res, obj) {
-                                                            t.equal(res.statusCode, 200, 'failed login 14')
-                                                            t.equal(obj.lockout, false, 'not locked out')
-
-                                                            client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.24' },
-                                                              function (err, req, res, obj) {
-                                                                t.equal(res.statusCode, 200, 'failed login 15')
-                                                                t.equal(obj.lockout, false, 'not locked out')
-
-                                                                client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.25' },
-                                                                  function (err, req, res, obj) {
-                                                                    t.equal(res.statusCode, 200, 'failed login 16')
-                                                                    t.equal(obj.lockout, false, 'not locked out')
-
-                                                                    client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.26' },
-                                                                      function (err, req, res, obj) {
-                                                                        t.equal(res.statusCode, 200, 'failed login 17')
-                                                                        t.equal(obj.lockout, false, 'not locked out')
-
-                                                                        client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.27' },
-                                                                          function (err, req, res, obj) {
-                                                                            t.equal(res.statusCode, 200, 'failed login 18')
-                                                                            t.equal(obj.lockout, false, 'locked out')
-
-                                                                            client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.28' },
-                                                                              function (err, req, res, obj) {
-                                                                                t.equal(res.statusCode, 200, 'failed login 19')
-                                                                                t.equal(obj.lockout, false, 'locked out')
-
-                                                                                client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.27' },
-                                                                                  function (err, req, res, obj) {
-                                                                                    t.equal(res.statusCode, 200, 'failed login 20')
-                                                                                    t.equal(obj.lockout, false, 'locked out')
-
-                                                                                    client.post('/failedLoginAttempt', { email: TEST_EMAIL, ip: '192.0.2.28' },
-                                                                                      function (err, req, res, obj) {
-                                                                                        t.equal(res.statusCode, 200, 'failed login 21')
-                                                                                        t.equal(obj.lockout, true, 'locked out')
-
-                                                                                        mcHelper.badLoginCheck(
-                                                                                          function (isOverBadLogins, isWayOverBadLogins) {
-                                                                                            t.equal(isOverBadLogins, false, 'is still not over bad logins')
-                                                                                            t.equal(isWayOverBadLogins, true, 'is now locked out')
-                                                                                            t.end()
-                                                                                          }
-                                                                                        )
-                                                                                      }
-                                                                                    )
-                                                                                  }
-                                                                                )
-                                                                              }
-                                                                            )
-                                                                          }
-                                                                        )
-                                                                      }
-                                                                    )
-                                                                  }
-                                                                )
-                                                              }
-                                                            )
-                                                          }
-                                                        )
-                                                      }
-                                                    )
-                                                  }
-                                                )
-                                              }
-                                            )
-                                          }
-                                        )
-                                      }
-                                    )
-                                  }
-                                )
-                              }
-                            )
-                          }
-                        )
-                      }
-                    )
-                  }
-                )
-              }
-            )
-          }
-        )
       }
     )
   }

--- a/test/remote/too_many_login_checks.js
+++ b/test/remote/too_many_login_checks.js
@@ -60,13 +60,11 @@ test(
     return client.postAsync('/failedLoginAttempt', { ip: TEST_IP, email: 'test-fail1@example.com', action: ACCOUNT_LOGIN })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'failed login 1')
-        t.equal(obj.lockout, false, 'not locked out')
 
         return client.postAsync('/failedLoginAttempt', { ip: TEST_IP, email: 'test-fail2@example.com', action: ACCOUNT_LOGIN })
       })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'failed login 2')
-        t.equal(obj.lockout, false, 'not locked out')
 
         return client.postAsync('/check', { ip: TEST_IP, email: 'test1@example.com', action: ACCOUNT_LOGIN })
       })
@@ -78,7 +76,6 @@ test(
       })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'failed login 3')
-        t.equal(obj.lockout, false, 'not locked out')
 
         return client.postAsync('/check', { ip: TEST_IP, email: 'test2@example.com', action: ACCOUNT_LOGIN })
       })


### PR DESCRIPTION
fixes #120 

I made this into two commits. The first commit removes all references to `isWayOverBadLogins` and anywhere where `lockout` is referenced. The second commit also removes `lf` (loginFailures) from EmailRecord. I was less sure whether this would be used in the future for some feature, perhaps email captcha. I suppose we can always go back to this commit and update as needed.

@rfk and @seanmonstar - r?