### PR TITLE
fix(dependencies): update restify to 4.1.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -471,9 +471,9 @@
       }
     },
     "restify": {
-      "version": "4.0.4",
-      "from": "restify@4.0.4",
-      "resolved": "https://registry.npmjs.org/restify/-/restify-4.0.4.tgz",
+      "version": "4.1.1",
+      "from": "restify@4.1.1",
+      "resolved": "https://registry.npmjs.org/restify/-/restify-4.1.1.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "0.1.5",
@@ -489,107 +489,6 @@
               "version": "0.2.3",
               "from": "precond@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
-            }
-          }
-        },
-        "bunyan": {
-          "version": "1.8.1",
-          "from": "bunyan@>=1.4.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.1.tgz",
-          "dependencies": {
-            "mv": {
-              "version": "2.1.1",
-              "from": "mv@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-              "dependencies": {
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.1 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    }
-                  }
-                },
-                "ncp": {
-                  "version": "2.0.0",
-                  "from": "ncp@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
-                },
-                "rimraf": {
-                  "version": "2.4.5",
-                  "from": "rimraf@>=2.4.0 <2.5.0",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-                  "dependencies": {
-                    "glob": {
-                      "version": "6.0.4",
-                      "from": "glob@>=6.0.1 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-                      "dependencies": {
-                        "inflight": {
-                          "version": "1.0.5",
-                          "from": "inflight@>=1.0.4 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "from": "inherits@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                        },
-                        "minimatch": {
-                          "version": "3.0.3",
-                          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.6",
-                              "from": "brace-expansion@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "0.4.2",
-                                  "from": "balanced-match@>=0.4.1 <0.5.0",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "path-is-absolute": {
-                          "version": "1.0.0",
-                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "safe-json-stringify": {
-              "version": "1.0.3",
-              "from": "safe-json-stringify@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz"
-            },
-            "moment": {
-              "version": "2.15.0",
-              "from": "moment@>=2.10.6 <3.0.0",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.0.tgz"
             }
           }
         },
@@ -653,9 +552,21 @@
           "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
         },
         "lru-cache": {
-          "version": "2.7.3",
-          "from": "lru-cache@>=2.5.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+          "version": "4.0.1",
+          "from": "lru-cache@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+          "dependencies": {
+            "pseudomap": {
+              "version": "1.0.2",
+              "from": "pseudomap@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+            },
+            "yallist": {
+              "version": "2.0.0",
+              "from": "yallist@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
+            }
+          }
         },
         "mime": {
           "version": "1.3.4",
@@ -663,9 +574,9 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         },
         "negotiator": {
-          "version": "0.5.3",
-          "from": "negotiator@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+          "version": "0.6.1",
+          "from": "negotiator@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
         },
         "node-uuid": {
           "version": "1.4.7",
@@ -695,9 +606,116 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         },
         "spdy": {
-          "version": "1.32.5",
-          "from": "spdy@>=1.26.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.32.5.tgz"
+          "version": "3.4.3",
+          "from": "spdy@>=3.3.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.3.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@>=2.2.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "handle-thing": {
+              "version": "1.2.5",
+              "from": "handle-thing@>=1.2.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz"
+            },
+            "http-deceiver": {
+              "version": "1.2.7",
+              "from": "http-deceiver@>=1.2.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz"
+            },
+            "select-hose": {
+              "version": "2.0.0",
+              "from": "select-hose@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz"
+            },
+            "spdy-transport": {
+              "version": "2.0.15",
+              "from": "spdy-transport@>=2.0.15 <3.0.0",
+              "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.15.tgz",
+              "dependencies": {
+                "hpack.js": {
+                  "version": "2.1.6",
+                  "from": "hpack.js@>=2.1.6 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    }
+                  }
+                },
+                "obuf": {
+                  "version": "1.1.1",
+                  "from": "obuf@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz"
+                },
+                "readable-stream": {
+                  "version": "2.1.5",
+                  "from": "readable-stream@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+                  "dependencies": {
+                    "buffer-shims": {
+                      "version": "1.0.0",
+                      "from": "buffer-shims@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                },
+                "wbuf": {
+                  "version": "1.7.2",
+                  "from": "wbuf@>=1.4.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
+                  "dependencies": {
+                    "minimalistic-assert": {
+                      "version": "1.0.0",
+                      "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
         },
         "tunnel-agent": {
           "version": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ip": "1.1.3",
     "memcached": "2.2.1",
     "newrelic": "1.30.1",
-    "restify": "4.0.4"
+    "restify": "4.1.1"
   },
   "devDependencies": {
     "ass": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",


### PR DESCRIPTION
Seems this was triggering an NSP warning: https://nodesecurity.io/advisories/106

The customs server isn't exposed to the public, but we should update anyways.