### PR TITLE
chore(config): Don't set allow ALLOWED_IPS by default.

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -165,11 +165,7 @@ module.exports = function (fs, path, url, convict) {
       doc: 'An array of IPs that will not be blocked or rate-limited.',
       format: Array,
       env: 'ALLOWED_IPS',
-      // These are IPs we know to be affiliated with Mozilla.
-      default: [
-        '63.245.214.162',
-        '63.245.214.168'
-      ]
+      default: []
     },
     allowedEmailDomains: {
       doc: 'An array of email domains that will not be blocked or rate-limited.',

--- a/test/remote/block_ip_tests.js
+++ b/test/remote/block_ip_tests.js
@@ -9,13 +9,16 @@ var mcHelper = require('../memcache-helper')
 
 var TEST_EMAIL = 'test@example.com'
 var TEST_IP = '192.0.2.1'
-var ALLOWED_IP = '63.245.214.162'
+var ALLOWED_IP = '192.0.3.1'
 
 var config = {
   listen: {
     port: 7000
   }
 }
+
+process.env.ALLOWED_IPS = ALLOWED_IP
+
 var testServer = new TestServer(config)
 
 var client = restify.createJsonClient({


### PR DESCRIPTION
Per conversation in https://github.com/mozilla-services/puppet-config/issues/2330, let's default this to an empty list to make life easier for Ops.  They were overriding these values in production anyway.