### PR TITLE
fix(logging): Don't attempt to log a 'msg' field.

### DIFF
--- a/lib/limits.js
+++ b/lib/limits.js
@@ -79,7 +79,7 @@ module.exports = function (config, mc, log) {
       var current = limits[key]
       var future = settings[key]
       if (typeof(current) !== typeof(future)) {
-        log.error({ op: 'limits.validate.err', key: key, msg: 'types do not match'})
+        log.error({ op: 'limits.validate.err', key: key, message: 'types do not match'})
         settings[key] = current
       }
       else if (!deepEqual(current, future)) {

--- a/lib/requestChecks.js
+++ b/lib/requestChecks.js
@@ -66,7 +66,7 @@ module.exports = function (config, mc, log) {
         settings[key] = current
       }
       else if (typeof(current) !== typeof(future)) {
-        log.error({ op: 'requestChecks.validate.err', key: key, msg: 'types do not match' })
+        log.error({ op: 'requestChecks.validate.err', key: key, message: 'types do not match' })
         settings[key] = current
       }
       else if (!deepEqual(current, future)) {


### PR DESCRIPTION
The logger used here (bunyan) treats 'msg' as a place to write its own formatted interpretation of the log message, so don't use it for our own purposes.  Instead let's log it under the name "message".  Bleh, I know, but simplest fix to get production logging up and running in the next train.  @jrgm r?

Fixes #140 