### PR TITLE
fix(blocklist): Convert date to milliseconds for file comparison

### DIFF
--- a/lib/ip_blocklist.js
+++ b/lib/ip_blocklist.js
@@ -67,7 +67,7 @@ module.exports = function (log, config) {
     var startTime = Date.now()
     return statFile(filePath)
       .then(function (fileStats) {
-        self.fileLastModified = fileStats.mtime
+        self.fileLastModified = fileStats.mtime.getTime()
         self.fileSize = fileStats.size
         return readFile(filePath, 'utf8')
       })
@@ -181,7 +181,7 @@ module.exports = function (log, config) {
 
     return statFile(self.filePath)
       .then(function (fileStats) {
-        var mtime = fileStats.mtime
+        var mtime = fileStats.mtime.getTime()
         if (mtime > self.fileLastModified) {
           return self.load(self.filePath)
         }


### PR DESCRIPTION
Per https://nodejs.org/api/fs.html#fs_class_fs_stats, uses `getTime()` on mtime, for use in comparisons.

Fixes #142 