### PR TITLE
fix(test): increase rateLimitInterval for send_violation_tests

### DIFF
--- a/test/remote/send_violations_tests.js
+++ b/test/remote/send_violations_tests.js
@@ -25,7 +25,7 @@ var config = {
     port: 7000
   },
   limits: {
-    rateLimitIntervalSeconds: 1
+    rateLimitIntervalSeconds: 10
   },
   reputationService: {
     enable: true,
@@ -299,7 +299,7 @@ test(
 )
 
 test(
-  'teardown test reptuation server',
+  'teardown test reputation server',
   function (t) {
     reputationServer.stop()
     t.equal(reputationServer.server.killed, true, 'test reputation server killed')


### PR DESCRIPTION
to make the test less flaky

refs: https://github.com/mozilla/fxa-customs-server/issues/153

I pulled this out of https://github.com/mozilla/fxa-customs-server/pull/152 since something else is going on there with the `/check` changes.