### PR TITLE
fix(retryAfter): Round blocking periods up instead of down.

### DIFF
--- a/lib/email_record.js
+++ b/lib/email_record.js
@@ -133,8 +133,8 @@ module.exports = function (limits, now) {
   }
 
   EmailRecord.prototype.retryAfter = function () {
-    var rateLimitAfter = Math.floor(((this.rl || 0) + limits.rateLimitIntervalMs - now()) / 1000)
-    var banAfter = Math.floor(((this.bk || 0) + limits.blockIntervalMs - now()) / 1000)
+    var rateLimitAfter = Math.ceil(((this.rl || 0) + limits.rateLimitIntervalMs - now()) / 1000)
+    var banAfter = Math.ceil(((this.bk || 0) + limits.blockIntervalMs - now()) / 1000)
     return Math.max(0, rateLimitAfter, banAfter)
   }
 

--- a/lib/ip_email_record.js
+++ b/lib/ip_email_record.js
@@ -73,7 +73,7 @@ module.exports = function (limits, now) {
   }
 
   IpEmailRecord.prototype.retryAfter = function () {
-    return Math.max(0, Math.floor(((this.rl || 0) + limits.rateLimitIntervalMs - now()) / 1000))
+    return Math.max(0, Math.ceil(((this.rl || 0) + limits.rateLimitIntervalMs - now()) / 1000))
   }
 
   IpEmailRecord.prototype.update = function (action) {

--- a/lib/ip_record.js
+++ b/lib/ip_record.js
@@ -166,8 +166,8 @@ module.exports = function (limits, now) {
   }
 
   IpRecord.prototype.retryAfter = function () {
-    var rateLimitAfter = Math.floor(((this.rl || 0) + limits.ipRateLimitBanDurationMs - now()) / 1000)
-    var banAfter = Math.floor(((this.bk || 0) + limits.blockIntervalMs - now()) / 1000)
+    var rateLimitAfter = Math.ceil(((this.rl || 0) + limits.ipRateLimitBanDurationMs - now()) / 1000)
+    var banAfter = Math.ceil(((this.bk || 0) + limits.blockIntervalMs - now()) / 1000)
     return Math.max(0, rateLimitAfter, banAfter)
   }
 

--- a/test/local/email_record_tests.js
+++ b/test/local/email_record_tests.js
@@ -216,9 +216,9 @@ test(
     er.addHit()
     er.addHit()
     t.equal(er.shouldBlock(), false, 'account is not blocked')
-    t.equal(er.update('accountCreate'), 0, 'email action above the email limit')
+    t.equal(er.update('accountCreate'), 1, 'email action above the email limit')
     t.equal(er.shouldBlock(), true, 'account is now blocked')
-    t.equal(er.update('accountCreate'), 0, 'email action in a blocked account')
+    t.equal(er.update('accountCreate'), 1, 'email action in a blocked account')
 
     t.equal(er.ub.length, 0, 'no unblock attempts')
     er.update('bogus', true)
@@ -228,15 +228,15 @@ test(
     t.equal(er.shouldBlock(), true, 'account is blocked due to rate limiting')
     t.equal(er.isBlocked(), false, 'account is not outright banned')
     t.equal(er.isRateLimited(), true, 'account is rate limited')
-    t.equal(er.update('accountCreate'), 1, 'email action is blocked')
+    t.equal(er.update('accountCreate'), 2, 'email action is blocked')
     t.equal(er.update('accountLogin'), 0, 'non-email action is not blocked')
     er.rl = 0
     er.bk = 2000
     t.equal(er.shouldBlock(), true, 'account is blocked due to being outright blocked')
     t.equal(er.isBlocked(), true, 'account is outright banned')
     t.equal(er.isRateLimited(), false, 'account is not rate limited')
-    t.equal(er.update('accountCreate'), 1, 'email action is blocked')
-    t.equal(er.update('accountLogin'), 1, 'non-email action is blocked')
+    t.equal(er.update('accountCreate'), 2, 'email action is blocked')
+    t.equal(er.update('accountLogin'), 2, 'non-email action is blocked')
 
     t.end()
   }

--- a/test/local/ip_email_record_tests.js
+++ b/test/local/ip_email_record_tests.js
@@ -125,7 +125,7 @@ test(
     ier.rl = 500
     t.equal(ier.retryAfter(), 0, 'just expired blocks can be retried immediately')
     ier.rl = 6000
-    t.equal(ier.retryAfter(), 5, 'unexpired blocks can be retried in a bit')
+    t.equal(ier.retryAfter(), 6, 'unexpired blocks can be retried in a bit')
     t.end()
   }
 )
@@ -192,9 +192,9 @@ test(
     ier.addBadLogin()
     ier.addBadLogin()
     t.equal(ier.shouldBlock(), false, 'account is not blocked')
-    t.equal(ier.update('accountLogin'), 0, 'action above the login limit')
+    t.equal(ier.update('accountLogin'), 1, 'action above the login limit')
     t.equal(ier.shouldBlock(), true, 'account is now blocked')
-    t.equal(ier.update('accountLogin'), 0, 'login action in a blocked account')
+    t.equal(ier.update('accountLogin'), 1, 'login action in a blocked account')
     t.end()
   }
 )


### PR DESCRIPTION
Fixes #158; @vbudhram r?; /cc @g-k 

Previously, the code would round your ban period down to the
nearest integral number of seconds.  Since the ban duration in
tests is only 1 second, this would occasionally cause it to be
rounded down to zero, leading to flaky test failures.

We now round the ban priod *up* to the nearest integral number
of seconds, which shouldn't have any significant impact on users
in production, but makes the tests much simpler to reason about.