### PR TITLE
feat(sms): Add support for rate-limiting sms actions

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -43,6 +43,12 @@ var EMAIL_SENDING_ACTION = {
   sendUnblockCode: true
 }
 
+// Actions that can send sms, and could make us
+// very annoying to a user if abused.
+var SMS_SENDING_ACTION = {
+  inviteUserSMS: true
+}
+
 module.exports = {
 
   isPasswordCheckingAction: function isPasswordCheckingAction(action) {
@@ -59,6 +65,9 @@ module.exports = {
 
   isEmailSendingAction: function isEmailSendingAction(action) {
     return EMAIL_SENDING_ACTION[action]
-  }
+  },
 
+  isSMSSendingAction: function isSMSSendingAction(action) {
+    return SMS_SENDING_ACTION[action]
+  }
 }

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -46,7 +46,7 @@ const EMAIL_SENDING_ACTION = {
 // Actions that can send sms, and could make us
 // very annoying to a user if abused.
 const SMS_SENDING_ACTION = {
-  inviteUserSms: true
+  connectDeviceSms: true
 }
 
 module.exports = {

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -4,7 +4,7 @@
 
 // Actions that, if allowed, would allow an attacker
 // to try a candidtate password against an account.
-var PASSWORD_CHECKING_ACTION = {
+const PASSWORD_CHECKING_ACTION = {
   accountLogin: true,
   accountDestroy: true,
   passwordChange: true
@@ -14,7 +14,7 @@ var PASSWORD_CHECKING_ACTION = {
 // to try a guess at a randomly-generated security code.
 // Code are higher entropy so we can allow more of these,
 // but if you're doing it a lot, you're probably a baddie.
-var CODE_VERIFYING_ACTION = {
+const CODE_VERIFYING_ACTION = {
   recoveryEmailVerifyCode: true,
   passwordForgotVerifyCode: true
 }
@@ -23,7 +23,7 @@ var CODE_VERIFYING_ACTION = {
 // to check whether an account exists for a particular user.
 // Basically any unauthenticated endpoint that takes
 // an email address as input.
-var ACCOUNT_STATUS_ACTION = {
+const ACCOUNT_STATUS_ACTION = {
   accountCreate: true,
   accountLogin: true,
   accountDestroy: true,
@@ -35,7 +35,7 @@ var ACCOUNT_STATUS_ACTION = {
 
 // Actions that send an email, and hence might make
 // us look like spammers if abused.
-var EMAIL_SENDING_ACTION = {
+const EMAIL_SENDING_ACTION = {
   accountCreate: true,
   recoveryEmailResendCode: true,
   passwordForgotSendCode: true,
@@ -45,29 +45,29 @@ var EMAIL_SENDING_ACTION = {
 
 // Actions that can send sms, and could make us
 // very annoying to a user if abused.
-var SMS_SENDING_ACTION = {
-  inviteUserSMS: true
+const SMS_SENDING_ACTION = {
+  inviteUserSms: true
 }
 
 module.exports = {
 
-  isPasswordCheckingAction: function isPasswordCheckingAction(action) {
+  isPasswordCheckingAction: function (action) {
     return PASSWORD_CHECKING_ACTION[action]
   },
 
-  isCodeVerifyingAction: function isCodeVerifyingAction(action) {
+  isCodeVerifyingAction: function (action) {
     return CODE_VERIFYING_ACTION[action]
   },
 
-  isAccountStatusAction: function isAccountStatusAction(action) {
+  isAccountStatusAction: function (action) {
     return ACCOUNT_STATUS_ACTION[action]
   },
 
-  isEmailSendingAction: function isEmailSendingAction(action) {
+  isEmailSendingAction: function (action) {
     return EMAIL_SENDING_ACTION[action]
   },
 
-  isSMSSendingAction: function isSMSSendingAction(action) {
+  isSmsSendingAction: function (action) {
     return SMS_SENDING_ACTION[action]
   }
 }

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -114,7 +114,7 @@ module.exports = function (fs, path, url, convict) {
           format: 'nat',
           env: 'SMS_RATE_LIMIT_INTERVAL_SECONDS'
         },
-        maxSMSs: {
+        maxSms: {
           doc: 'Number of sms sent within rateLimitIntervalSeconds before throttling',
           default: 5,
           format: 'nat',

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -107,6 +107,20 @@ module.exports = function (fs, path, url, convict) {
         format: 'nat',
         env: 'IP_RATE_LIMIT_BAN_DURATION_SECONDS'
       },
+      smsRateLimit: {
+        limitIntervalSeconds: {
+          doc: 'Duration of automatic throttling for sms',
+          default: 60 * 15,
+          format: 'nat',
+          env: 'SMS_RATE_LIMIT_INTERVAL_SECONDS'
+        },
+        maxSMSs: {
+          doc: 'Number of sms sent within rateLimitIntervalSeconds before throttling',
+          default: 5,
+          format: 'nat',
+          env: 'MAX_SMS'
+        }
+      },
       uidRateLimit: {
         limitIntervalSeconds: {
           doc: 'Duration of automatic throttling for uids',

--- a/lib/ip_record.js
+++ b/lib/ip_record.js
@@ -141,9 +141,9 @@ module.exports = function (limits, now) {
   IpRecord.prototype.addSmsRequest = function (info) {
     info = info || {}
     var t = now()
-    var smsNumber = info.smsNumber || ''
+    var phoneNumber = info.phoneNumber || ''
     this.trimSmsRequests(t)
-    this.sms.push({ t: t, u: smsNumber })
+    this.sms.push({ t: t, u: phoneNumber })
   }
 
   IpRecord.prototype.trimSmsRequests = function (now) {
@@ -199,7 +199,7 @@ module.exports = function (limits, now) {
     return Math.max(0, rateLimitAfter, banAfter)
   }
 
-  IpRecord.prototype.update = function (action, email, smsNumber) {
+  IpRecord.prototype.update = function (action, email, phoneNumber) {
     // ip block is explicit, no escape hatches
     if (this.isBlocked()) {
       return this.retryAfter()
@@ -236,8 +236,8 @@ module.exports = function (limits, now) {
     }
 
     // Increment sms request count and throttle if needed
-    if (actions.isSmsSendingAction(action) && smsNumber) {
-      this.addSmsRequest({ smsNumber: smsNumber })
+    if (actions.isSmsSendingAction(action) && phoneNumber) {
+      this.addSmsRequest({ phoneNumber: phoneNumber })
       if (this.isOverSmsLimit()){
         // If you do more than the limit this can extend the ban.
         this.rateLimit()

--- a/lib/ip_record.js
+++ b/lib/ip_record.js
@@ -124,8 +124,8 @@ module.exports = function (limits, now) {
     this.as = this._trim(now, this.as, limits.maxAccountStatusCheck)
   }
 
-  IpRecord.prototype.isOverSMSLimit = function () {
-    this.trimSMSRequests(now())
+  IpRecord.prototype.isOverSmsLimit = function () {
+    this.trimSmsRequests(now())
     // Limit based on number of unique sms request sent by this IP
     var count = 0
     var seen = {}
@@ -135,19 +135,19 @@ module.exports = function (limits, now) {
         seen[info.u] = true
       }
     })
-    return count > limits.maxSMSs
+    return count > limits.maxSms
   }
 
-  IpRecord.prototype.addSMSRequest = function (info) {
+  IpRecord.prototype.addSmsRequest = function (info) {
     info = info || {}
     var t = now()
     var smsNumber = info.smsNumber || ''
-    this.trimSMSRequests(t)
+    this.trimSmsRequests(t)
     this.sms.push({ t: t, u: smsNumber })
   }
 
-  IpRecord.prototype.trimSMSRequests = function (now) {
-    this.sms = this._trim(now, this.sms, limits.maxSMSs)
+  IpRecord.prototype.trimSmsRequests = function (now) {
+    this.sms = this._trim(now, this.sms, limits.maxSms)
   }
 
   IpRecord.prototype._trim = function (now, items, maxUnique) {
@@ -236,9 +236,9 @@ module.exports = function (limits, now) {
     }
 
     // Increment sms request count and throttle if needed
-    if (actions.isSMSSendingAction(action) && smsNumber) {
-      this.addSMSRequest({ smsNumber: smsNumber })
-      if (this.isOverSMSLimit()){
+    if (actions.isSmsSendingAction(action) && smsNumber) {
+      this.addSmsRequest({ smsNumber: smsNumber })
+      if (this.isOverSmsLimit()){
         // If you do more than the limit this can extend the ban.
         this.rateLimit()
       }

--- a/lib/ip_record.js
+++ b/lib/ip_record.js
@@ -20,11 +20,12 @@ module.exports = function (limits, now) {
   IpRecord.parse = function (object) {
     var rec = new IpRecord()
     object = object || {}
-    rec.bk = object.bk // timestamp when the account was blocked
-    rec.lf = object.lf || []  // timestamp+email+errno when failed login attempts occurred
-    rec.vc = object.vc || []  // timestamp+email when code verifications occurred
-    rec.as = object.as || []  // timestamp+email when account status checks occurred
-    rec.rl = object.rl  // timestamp when the account was rate-limited
+    rec.bk = object.bk          // timestamp when the account was blocked
+    rec.lf = object.lf || []    // timestamp+email+errno when failed login attempts occurred
+    rec.vc = object.vc || []    // timestamp+email when code verifications occurred
+    rec.as = object.as || []    // timestamp+email when account status checks occurred
+    rec.sms = object.sms || []  // timestamp+sms when sms sent
+    rec.rl = object.rl          // timestamp when the account was rate-limited
     return rec
   }
 
@@ -123,6 +124,32 @@ module.exports = function (limits, now) {
     this.as = this._trim(now, this.as, limits.maxAccountStatusCheck)
   }
 
+  IpRecord.prototype.isOverSMSLimit = function () {
+    this.trimSMSRequests(now())
+    // Limit based on number of unique sms request sent by this IP
+    var count = 0
+    var seen = {}
+    this.sms.forEach(function(info) {
+      if (!(info.u in seen)) {
+        count += 1
+        seen[info.u] = true
+      }
+    })
+    return count > limits.maxSMSs
+  }
+
+  IpRecord.prototype.addSMSRequest = function (info) {
+    info = info || {}
+    var t = now()
+    var smsNumber = info.smsNumber || ''
+    this.trimSMSRequests(t)
+    this.sms.push({ t: t, u: smsNumber })
+  }
+
+  IpRecord.prototype.trimSMSRequests = function (now) {
+    this.sms = this._trim(now, this.sms, limits.maxSMSs)
+  }
+
   IpRecord.prototype._trim = function (now, items, maxUnique) {
     if (items.length === 0) { return items }
     // the list is naturally ordered from oldest to newest,
@@ -163,6 +190,7 @@ module.exports = function (limits, now) {
   IpRecord.prototype.rateLimit = function () {
     this.rl = now()
     this.as = []
+    this.sms = []
   }
 
   IpRecord.prototype.retryAfter = function () {
@@ -171,7 +199,7 @@ module.exports = function (limits, now) {
     return Math.max(0, rateLimitAfter, banAfter)
   }
 
-  IpRecord.prototype.update = function (action, email) {
+  IpRecord.prototype.update = function (action, email, smsNumber) {
     // ip block is explicit, no escape hatches
     if (this.isBlocked()) {
       return this.retryAfter()
@@ -203,6 +231,15 @@ module.exports = function (limits, now) {
       }
       if (this.isOverBadLogins()) {
         // If you attempt more logins while rate-limited, this can extend the ban.
+        this.rateLimit()
+      }
+    }
+
+    // Increment sms request count and throttle if needed
+    if (actions.isSMSSendingAction(action) && smsNumber) {
+      this.addSMSRequest({ smsNumber: smsNumber })
+      if (this.isOverSMSLimit()){
+        // If you do more than the limit this can extend the ban.
         this.rateLimit()
       }
     }

--- a/lib/limits.js
+++ b/lib/limits.js
@@ -33,7 +33,7 @@ module.exports = function (config, mc, log) {
     this.uidRateLimitBanDurationMs = this.uidRateLimit.banDurationSeconds * 1000
     this.uidRateLimitIntervalMs = this.uidRateLimit.limitIntervalSeconds * 1000
     this.smsRateLimit = settings.smsRateLimit || {}
-    this.maxSMSs = settings.smsRateLimit.maxSMSs
+    this.maxSms = settings.smsRateLimit.maxSms
     this.smsRateLimitIntervalSeconds = this.smsRateLimit.limitIntervalSeconds
     this.smsRateLimitIntervalMs = this.smsRateLimitIntervalSeconds * 1000
 

--- a/lib/limits.js
+++ b/lib/limits.js
@@ -32,6 +32,11 @@ module.exports = function (config, mc, log) {
     this.maxChecksPerUid = this.uidRateLimit.maxChecks
     this.uidRateLimitBanDurationMs = this.uidRateLimit.banDurationSeconds * 1000
     this.uidRateLimitIntervalMs = this.uidRateLimit.limitIntervalSeconds * 1000
+    this.smsRateLimit = settings.smsRateLimit || {}
+    this.maxSMSs = settings.smsRateLimit.maxSMSs
+    this.smsRateLimitIntervalSeconds = this.smsRateLimit.limitIntervalSeconds
+    this.smsRateLimitIntervalMs = this.smsRateLimitIntervalSeconds * 1000
+
     return this
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -157,7 +157,7 @@ module.exports = function createServer(config, log) {
             var wantsUnblock = req.body.payload && req.body.payload.unblockCode
             var blockEmail = emailRecord.update(action, !!wantsUnblock)
             var blockIpEmail = ipEmailRecord.update(action)
-            var blockIp = ipRecord.update(action, email)
+            var blockIp = ipRecord.update(action, email, smsNumber)
 
             var blockSMS = 0
             if (smsRecord) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -59,6 +59,7 @@ module.exports = function createServer(config, log) {
   var EmailRecord = require('./email_record')(limits)
   var IpRecord = require('./ip_record')(limits)
   var UidRecord = require('./uid_record')(limits)
+  var smsRecord = require('./sms_record')(limits)
 
   var handleBan = P.promisify(require('./bans/handler')(config.memcache.recordLifetimeSeconds, mc, EmailRecord, IpRecord, log))
 
@@ -77,7 +78,7 @@ module.exports = function createServer(config, log) {
     throw err
   }
 
-  function fetchRecords(email, ip) {
+  function fetchRecords(email, ip, smsNumber) {
     var promises = [
       // get records and ignore errors by returning a new record
       mc.getAsync(email).then(EmailRecord.parse, EmailRecord.parse),
@@ -85,6 +86,13 @@ module.exports = function createServer(config, log) {
       mc.getAsync(ip + email).then(IpEmailRecord.parse, IpEmailRecord.parse),
       reputationService.get(ip)
     ]
+
+    // Check against SMS records to make sure that this request
+    // can send SMS
+    if (smsNumber) {
+      promises.push(mc.getAsync(smsNumber).then(smsRecord.parse, smsRecord.parse))
+    }
+
     return P.all(promises)
   }
 
@@ -93,14 +101,18 @@ module.exports = function createServer(config, log) {
     return mc.setAsync(key, record, lifetime)
   }
 
-  function setRecords(email, ip, emailRecord, ipRecord, ipEmailRecord) {
-    return P.all(
-      [
-        setRecord(email, emailRecord),
-        setRecord(ip, ipRecord),
-        setRecord(ip + email, ipEmailRecord)
-      ]
-    )
+  function setRecords(email, ip, emailRecord, ipRecord, ipEmailRecord, smsNumber, smsRecord) {
+    var promises =       [
+      setRecord(email, emailRecord),
+      setRecord(ip, ipRecord),
+      setRecord(ip + email, ipEmailRecord)
+    ]
+
+    if (smsNumber && smsRecord) {
+      promises.push(setRecord(smsNumber, smsRecord))
+    }
+
+    return P.all(promises)
   }
 
   function max(prev, cur) {
@@ -116,6 +128,7 @@ module.exports = function createServer(config, log) {
     function (req, res, next) {
       var email = req.body.email
       var ip = req.body.ip
+      var smsNumber = req.body.smsNumber // SMS Number is optional
       var action = req.body.action
       var headers = req.body.headers || {}
       var payload = req.body.payload || {}
@@ -128,9 +141,9 @@ module.exports = function createServer(config, log) {
       }
       email = normalizedEmail(email)
 
-      fetchRecords(email, ip)
+      fetchRecords(email, ip, smsNumber)
         .spread(
-          function (emailRecord, ipRecord, ipEmailRecord, reputation) {
+          function (emailRecord, ipRecord, ipEmailRecord, reputation, smsRecord) {
             if (ipRecord.isBlocked()) {
               // a blocked ip should just be ignored completely
               // it's malicious, it shouldn't penalize emails or allow
@@ -141,17 +154,21 @@ module.exports = function createServer(config, log) {
               }
             }
 
-
             var wantsUnblock = req.body.payload && req.body.payload.unblockCode
             var blockEmail = emailRecord.update(action, !!wantsUnblock)
             var blockIpEmail = ipEmailRecord.update(action)
             var blockIp = ipRecord.update(action, email)
 
+            var blockSMS = 0
+            if (smsRecord) {
+              blockSMS = smsRecord.update(action)
+            }
+
             if (blockIpEmail && ipEmailRecord.unblockIfReset(emailRecord.pr)) {
               blockIpEmail = 0
             }
 
-            var retryAfter = [blockEmail, blockIpEmail, blockIp].reduce(max)
+            var retryAfter = [blockEmail, blockIpEmail, blockIp, blockSMS].reduce(max)
             var block = retryAfter > 0
             var suspect = false
             var blockReason = null
@@ -186,7 +203,7 @@ module.exports = function createServer(config, log) {
               blockReason = blockReasons.IP_BAD_REPUTATION
             }
 
-            return setRecords(email, ip, emailRecord, ipRecord, ipEmailRecord)
+            return setRecords(email, ip, emailRecord, ipRecord, ipEmailRecord, smsNumber, smsRecord)
               .then(
                 function () {
                   return {

--- a/lib/server.js
+++ b/lib/server.js
@@ -78,7 +78,7 @@ module.exports = function createServer(config, log) {
     throw err
   }
 
-  function fetchRecords(email, ip, smsNumber) {
+  function fetchRecords(email, ip, phoneNumber) {
     var promises = [
       // get records and ignore errors by returning a new record
       mc.getAsync(email).then(EmailRecord.parse, EmailRecord.parse),
@@ -88,9 +88,9 @@ module.exports = function createServer(config, log) {
     ]
 
     // Check against SMS records to make sure that this request
-    // can send SMS
-    if (smsNumber) {
-      promises.push(mc.getAsync(smsNumber).then(smsRecord.parse, smsRecord.parse))
+    // can send to this phone number
+    if (phoneNumber) {
+      promises.push(mc.getAsync(phoneNumber).then(smsRecord.parse, smsRecord.parse))
     }
 
     return P.all(promises)
@@ -101,15 +101,15 @@ module.exports = function createServer(config, log) {
     return mc.setAsync(key, record, lifetime)
   }
 
-  function setRecords(email, ip, emailRecord, ipRecord, ipEmailRecord, smsNumber, smsRecord) {
+  function setRecords(email, ip, emailRecord, ipRecord, ipEmailRecord, phoneNumber, smsRecord) {
     var promises =       [
       setRecord(email, emailRecord),
       setRecord(ip, ipRecord),
       setRecord(ip + email, ipEmailRecord)
     ]
 
-    if (smsNumber && smsRecord) {
-      promises.push(setRecord(smsNumber, smsRecord))
+    if (phoneNumber && smsRecord) {
+      promises.push(setRecord(phoneNumber, smsRecord))
     }
 
     return P.all(promises)
@@ -128,7 +128,6 @@ module.exports = function createServer(config, log) {
     function (req, res, next) {
       var email = req.body.email
       var ip = req.body.ip
-      var smsNumber = req.body.smsNumber // SMS Number is optional
       var action = req.body.action
       var headers = req.body.headers || {}
       var payload = req.body.payload || {}
@@ -141,7 +140,14 @@ module.exports = function createServer(config, log) {
       }
       email = normalizedEmail(email)
 
-      fetchRecords(email, ip, smsNumber)
+      // Phone number is optional
+      var phoneNumber
+      if (req.body.payload && req.body.payload.phoneNumber) {
+        phoneNumber = req.body.payload.phoneNumber
+      }
+
+
+      fetchRecords(email, ip, phoneNumber)
         .spread(
           function (emailRecord, ipRecord, ipEmailRecord, reputation, smsRecord) {
             if (ipRecord.isBlocked()) {
@@ -157,7 +163,7 @@ module.exports = function createServer(config, log) {
             var wantsUnblock = req.body.payload && req.body.payload.unblockCode
             var blockEmail = emailRecord.update(action, !!wantsUnblock)
             var blockIpEmail = ipEmailRecord.update(action)
-            var blockIp = ipRecord.update(action, email, smsNumber)
+            var blockIp = ipRecord.update(action, email, phoneNumber)
 
             var blockSMS = 0
             if (smsRecord) {
@@ -203,7 +209,7 @@ module.exports = function createServer(config, log) {
               blockReason = blockReasons.IP_BAD_REPUTATION
             }
 
-            return setRecords(email, ip, emailRecord, ipRecord, ipEmailRecord, smsNumber, smsRecord)
+            return setRecords(email, ip, emailRecord, ipRecord, ipEmailRecord, phoneNumber, smsRecord)
               .then(
                 function () {
                   return {

--- a/lib/sms_record.js
+++ b/lib/sms_record.js
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var actions = require('./actions')
+
+// Keep track of events tied to specific sms number
+module.exports = function (limits, now) {
+
+  now = now || Date.now
+
+  function SMSRecord() {
+    this.xs = []
+  }
+
+  SMSRecord.parse = function (object) {
+    var rec = new SMSRecord()
+    object = object || {}
+    rec.rl = object.rl       // timestamp when the account was rate-limited
+    rec.xs = object.xs || [] // timestamps when sms were sent
+    return rec
+  }
+
+  SMSRecord.prototype.getMinLifetimeMS = function () {
+    return limits.smsRateLimitIntervalMs
+  }
+
+  SMSRecord.prototype.isOverSMSLimit = function () {
+    this.trimHits(now())
+    return this.xs.length > limits.maxSMSs
+  }
+
+  SMSRecord.prototype.trimHits = function (now) {
+    if (this.xs.length === 0) { return }
+    // xs is naturally ordered from oldest to newest
+    // and we only need to keep up to limits.sms + 1
+
+    var i = this.xs.length - 1
+    var n = 0
+    var hit = this.xs[i]
+    while (hit > (now - limits.smsRateLimitIntervalMs) && n <= limits.maxSMSs) {
+      hit = this.xs[--i]
+      n++
+    }
+    this.xs = this.xs.slice(i + 1)
+  }
+
+  SMSRecord.prototype.addHit = function () {
+    this.xs.push(now())
+  }
+
+  SMSRecord.prototype.isRateLimited = function () {
+    return !!(this.rl && (now() - this.rl < limits.smsRateLimitIntervalMs))
+  }
+
+  SMSRecord.prototype.rateLimit = function () {
+    this.rl = now()
+    this.xs = []
+  }
+
+  SMSRecord.prototype.retryAfter = function () {
+    var rateLimitAfter = Math.ceil(((this.rl || 0) + limits.smsRateLimitIntervalMs - now()) / 1000)
+    return Math.max(0, rateLimitAfter)
+  }
+
+  SMSRecord.prototype.update = function (action) {
+
+    if (this.isRateLimited()) {
+      return this.retryAfter()
+    }
+
+    if (actions.isSMSSendingAction(action)) {
+      this.addHit()
+
+      if (this.isOverSMSLimit()) {
+        this.rateLimit()
+        return this.retryAfter()
+      }
+    }
+
+    return 0
+  }
+
+  return SMSRecord
+}

--- a/lib/sms_record.js
+++ b/lib/sms_record.js
@@ -25,9 +25,9 @@ module.exports = function (limits, now) {
     return limits.smsRateLimitIntervalMs
   }
 
-  SMSRecord.prototype.isOverSMSLimit = function () {
+  SMSRecord.prototype.isOverSmsLimit = function () {
     this.trimHits(now())
-    return this.xs.length > limits.maxSMSs
+    return this.xs.length > limits.maxSms
   }
 
   SMSRecord.prototype.trimHits = function (now) {
@@ -38,7 +38,7 @@ module.exports = function (limits, now) {
     var i = this.xs.length - 1
     var n = 0
     var hit = this.xs[i]
-    while (hit > (now - limits.smsRateLimitIntervalMs) && n <= limits.maxSMSs) {
+    while (hit > (now - limits.smsRateLimitIntervalMs) && n <= limits.maxSms) {
       hit = this.xs[--i]
       n++
     }
@@ -69,10 +69,10 @@ module.exports = function (limits, now) {
       return this.retryAfter()
     }
 
-    if (actions.isSMSSendingAction(action)) {
+    if (actions.isSmsSendingAction(action)) {
       this.addHit()
 
-      if (this.isOverSMSLimit()) {
+      if (this.isOverSmsLimit()) {
         this.rateLimit()
         return this.retryAfter()
       }

--- a/lib/sms_record.js
+++ b/lib/sms_record.js
@@ -10,14 +10,14 @@ module.exports = function (limits, now) {
   now = now || Date.now
 
   function SMSRecord() {
-    this.xs = []
+    this.sms = []
   }
 
   SMSRecord.parse = function (object) {
     var rec = new SMSRecord()
     object = object || {}
     rec.rl = object.rl       // timestamp when the account was rate-limited
-    rec.xs = object.xs || [] // timestamps when sms were sent
+    rec.sms = object.sms || [] // timestamps when sms were sent
     return rec
   }
 
@@ -27,26 +27,26 @@ module.exports = function (limits, now) {
 
   SMSRecord.prototype.isOverSmsLimit = function () {
     this.trimHits(now())
-    return this.xs.length > limits.maxSms
+    return this.sms.length > limits.maxSms
   }
 
   SMSRecord.prototype.trimHits = function (now) {
-    if (this.xs.length === 0) { return }
+    if (this.sms.length === 0) { return }
     // xs is naturally ordered from oldest to newest
     // and we only need to keep up to limits.sms + 1
 
-    var i = this.xs.length - 1
+    var i = this.sms.length - 1
     var n = 0
-    var hit = this.xs[i]
+    var hit = this.sms[i]
     while (hit > (now - limits.smsRateLimitIntervalMs) && n <= limits.maxSms) {
-      hit = this.xs[--i]
+      hit = this.sms[--i]
       n++
     }
-    this.xs = this.xs.slice(i + 1)
+    this.sms = this.sms.slice(i + 1)
   }
 
   SMSRecord.prototype.addHit = function () {
-    this.xs.push(now())
+    this.sms.push(now())
   }
 
   SMSRecord.prototype.isRateLimited = function () {
@@ -55,7 +55,7 @@ module.exports = function (limits, now) {
 
   SMSRecord.prototype.rateLimit = function () {
     this.rl = now()
-    this.xs = []
+    this.sms = []
   }
 
   SMSRecord.prototype.retryAfter = function () {

--- a/test/local/sms_record_tests.js
+++ b/test/local/sms_record_tests.js
@@ -10,7 +10,7 @@ function now() {
 }
 var limits = {
   smsRateLimitIntervalMs: 1000,
-  maxSMSs: 1
+  maxSms: 1
 }
 
 function simpleSMSRecord() {
@@ -33,7 +33,7 @@ test('rate limit works',
 test('retryAfter works',
   function (t) {
     var sr = simpleSMSRecord()
-    var action = 'inviteUserSMS'
+    var action = 'inviteUserSms'
 
     sr.update(action)
     t.equal(sr.isRateLimited(), false, 'record is not rate limited')

--- a/test/local/sms_record_tests.js
+++ b/test/local/sms_record_tests.js
@@ -33,7 +33,7 @@ test('rate limit works',
 test('retryAfter works',
   function (t) {
     var sr = simpleSMSRecord()
-    var action = 'inviteUserSms'
+    var action = 'connectDeviceSms'
 
     sr.update(action)
     t.equal(sr.isRateLimited(), false, 'record is not rate limited')

--- a/test/local/sms_record_tests.js
+++ b/test/local/sms_record_tests.js
@@ -1,0 +1,80 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+require('ass')
+var test = require('tap').test
+var smsRecord = require('../../lib/sms_record')
+
+function now() {
+  return 240 * 1000
+}
+var limits = {
+  smsRateLimitIntervalMs: 1000,
+  maxSMSs: 1
+}
+
+function simpleSMSRecord() {
+  return new (smsRecord(limits, now))()
+}
+
+test('rate limit works',
+  function (t) {
+    var sr = simpleSMSRecord()
+
+    t.equal(sr.isRateLimited(), false, 'record is not rate limited')
+    sr.rateLimit()
+    t.equal(sr.isRateLimited(), true, 'record is rate limited')
+    sr.rl = now() - 60 * 1000
+    t.equal(sr.isRateLimited(), false, 'record is not rate limited')
+    t.end()
+  }
+)
+
+test('retryAfter works',
+  function (t) {
+    var sr = simpleSMSRecord()
+    var action = 'inviteUserSMS'
+
+    sr.update(action)
+    t.equal(sr.isRateLimited(), false, 'record is not rate limited')
+    sr.update(action)
+    t.equal(sr.isRateLimited(), true, 'record is rate limited')
+    t.end()
+  }
+)
+
+test(
+  'parse works',
+  function (t) {
+    var sr = simpleSMSRecord()
+    var copy1 = (smsRecord(limits, now)).parse(sr)
+
+    t.equal(copy1.isRateLimited(), false, 'record is not rate limited')
+    sr.rateLimit()
+    t.equal(sr.isRateLimited(), true, 'original object is now rate limited')
+    var copy2 = (smsRecord(limits, now)).parse(sr)
+    t.equal(copy2.isRateLimited(), true, 'copied object is rate limited')
+    t.end()
+  }
+)
+
+test(
+  'no action update works',
+  function (t) {
+    var sr = simpleSMSRecord()
+
+    t.equal(sr.update(), 0, 'update with no action does nothing')
+    t.end()
+  }
+)
+
+
+test(
+  'getMinLifetimeMS works',
+  function (t) {
+    var sr = simpleSMSRecord()
+
+    t.equal(sr.getMinLifetimeMS(), limits.smsRateLimitIntervalMs, 'gets the min sms lifetime')
+    t.end()
+  }
+)

--- a/test/memcache-helper.js
+++ b/test/memcache-helper.js
@@ -20,6 +20,10 @@ var config = {
     maxBadLoginsPerIp: Number(process.env.MAX_BAD_LOGINS_PER_IP) || 3,
     ipRateLimitIntervalSeconds: Number(process.env.IP_RATE_LIMIT_INTERVAL_SECONDS) || 60 * 15,
     ipRateLimitBanDurationSeconds: Number(process.env.IP_RATE_LIMIT_BAN_DURATION_SECONDS) || 60 * 15,
+    smsRateLimit: {
+      limitIntervalSeconds: Number(process.env.SMS_RATE_LIMIT_INTERVAL_SECONDS) || 60 * 15,
+      maxSMSs: Number(process.env.MAX_SMS) || 2
+    },
     uidRateLimit: {
       limitIntervalSeconds: Number(process.env.UID_RATE_LIMIT_INTERVAL_SECONDS) || 60 * 15,
       banDurationSeconds: Number(process.env.UID_RATE_LIMIT_BAN_DURATION_SECONDS) || 60 * 15,

--- a/test/memcache-helper.js
+++ b/test/memcache-helper.js
@@ -22,7 +22,7 @@ var config = {
     ipRateLimitBanDurationSeconds: Number(process.env.IP_RATE_LIMIT_BAN_DURATION_SECONDS) || 60 * 15,
     smsRateLimit: {
       limitIntervalSeconds: Number(process.env.SMS_RATE_LIMIT_INTERVAL_SECONDS) || 60 * 15,
-      maxSMSs: Number(process.env.MAX_SMS) || 2
+      maxSms: Number(process.env.MAX_SMS) || 2
     },
     uidRateLimit: {
       limitIntervalSeconds: Number(process.env.UID_RATE_LIMIT_INTERVAL_SECONDS) || 60 * 15,

--- a/test/remote/too_many_sms.js
+++ b/test/remote/too_many_sms.js
@@ -1,0 +1,117 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+var test = require('tap').test
+var TestServer = require('../test_server')
+var Promise = require('bluebird')
+var restify = Promise.promisifyAll(require('restify'))
+var mcHelper = require('../memcache-helper')
+
+var TEST_IP = '192.0.2.1'
+var TEST_IP2 = '192.0.2.2'
+var TEST_IP3 = '192.0.2.3'
+var INVITE_USER_SMS = 'inviteUserSMS'
+var SMS_NUMBER = '14071234567'
+
+var config = {
+  listen: {
+    port: 7000
+  }
+}
+
+// Override limit values for testing
+process.env.SMS_RATE_LIMIT_INTERVAL_SECONDS = 1
+process.env.MAX_SMS = 2
+
+var testServer = new TestServer(config)
+
+var client = restify.createJsonClient({
+  url: 'http://127.0.0.1:' + config.listen.port
+})
+
+Promise.promisifyAll(client, { multiArgs: true })
+
+test(
+  'startup',
+  function (t) {
+    testServer.start(function (err) {
+      t.type(testServer.server, 'object', 'test server was started')
+      t.notOk(err, 'no errors were returned')
+      t.end()
+    })
+  }
+)
+
+test(
+  'clear everything',
+  function (t) {
+    mcHelper.clearEverything(
+      function (err) {
+        t.notOk(err, 'no errors were returned')
+        t.end()
+      }
+    )
+  }
+)
+
+test(
+  '/check `inviteUserSMS` by number',
+  function (t) {
+
+    // Send requests until throttled
+    return client.postAsync('/check', { ip: TEST_IP, email: 'test1@example.com', smsNumber: SMS_NUMBER, action: INVITE_USER_SMS })
+      .spread(function(req, res, obj){
+        t.equal(res.statusCode, 200, 'returns a 200')
+        t.equal(obj.block, false, 'not rate limited')
+        return client.postAsync('/check', { ip: TEST_IP2, email: 'test2@example.com', smsNumber: SMS_NUMBER, action: INVITE_USER_SMS })
+      })
+      .spread(function(req, res, obj){
+        t.equal(res.statusCode, 200, 'returns a 200')
+        t.equal(obj.block, false, 'not rate limited')
+        return client.postAsync('/check', { ip: TEST_IP3, email: 'test3@example.com', smsNumber: SMS_NUMBER, action: INVITE_USER_SMS })
+      })
+      .spread(function(req, res, obj){
+        t.equal(res.statusCode, 200, 'returns a 200')
+        t.equal(obj.block, true, 'rate limited')
+        t.equal(obj.retryAfter, 1, 'rate limit retry amount')
+
+        // Delay ~1s for rate limit to go away
+        return Promise.delay(1010)
+      })
+
+      // Reissue requests to verify that throttling is disabled
+      .then(function(){
+        return client.postAsync('/check', { ip: TEST_IP, email: 'test1@example.com', action: INVITE_USER_SMS })
+      })
+      .spread(function(req, res, obj){
+        t.equal(res.statusCode, 200, 'returns a 200')
+        t.equal(obj.block, false, 'not rate limited')
+        t.end()
+      })
+      .catch(function(err){
+        t.fail(err)
+        t.end()
+      })
+  }
+)
+
+test(
+  'clear everything',
+  function (t) {
+    mcHelper.clearEverything(
+      function (err) {
+        t.notOk(err, 'no errors were returned')
+        t.end()
+      }
+    )
+  }
+)
+
+test(
+  'teardown',
+  function (t) {
+    testServer.stop()
+    t.equal(testServer.server.killed, true, 'test server has been killed')
+    t.end()
+  }
+)

--- a/test/remote/too_many_sms.js
+++ b/test/remote/too_many_sms.js
@@ -10,7 +10,7 @@ var TEST_IP = '192.0.2.1'
 var TEST_IP2 = '192.0.2.2'
 var TEST_IP3 = '192.0.2.3'
 var TEST_IP4 = '192.0.2.4'
-var INVITE_USER_SMS = 'inviteUserSMS'
+var INVITE_USER_SMS = 'inviteUserSms'
 var SMS_NUMBER = '14071234567'
 
 var config = {
@@ -59,7 +59,7 @@ test(
 )
 
 test(
-  '/check `inviteUserSMS` by number',
+  '/check `inviteUserSms` by number',
   function (t) {
 
     // Send requests until throttled
@@ -100,7 +100,7 @@ test(
 )
 
 test(
-  '/check `inviteUserSMS` by ip',
+  '/check `inviteUserSms` by ip',
   function (t) {
 
     // Send requests until throttled

--- a/test/remote/too_many_sms.js
+++ b/test/remote/too_many_sms.js
@@ -10,7 +10,7 @@ var TEST_IP = '192.0.2.1'
 var TEST_IP2 = '192.0.2.2'
 var TEST_IP3 = '192.0.2.3'
 var TEST_IP4 = '192.0.2.4'
-var INVITE_USER_SMS = 'inviteUserSms'
+var CONNECT_DEVICE_SMS = 'connectDeviceSms'
 var SMS_NUMBER = '14071234567'
 
 var config = {
@@ -59,20 +59,20 @@ test(
 )
 
 test(
-  '/check `inviteUserSms` by number',
+  '/check `connectDeviceSms` by number',
   function (t) {
 
     // Send requests until throttled
-    return client.postAsync('/check', { ip: TEST_IP, email: 'test1@example.com', smsNumber: SMS_NUMBER, action: INVITE_USER_SMS })
+    return client.postAsync('/check', { ip: TEST_IP, email: 'test1@example.com', smsNumber: SMS_NUMBER, action: CONNECT_DEVICE_SMS })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'returns a 200')
         t.equal(obj.block, false, 'not rate limited')
-        return client.postAsync('/check', { ip: TEST_IP2, email: 'test2@example.com', smsNumber: SMS_NUMBER, action: INVITE_USER_SMS })
+        return client.postAsync('/check', { ip: TEST_IP2, email: 'test2@example.com', smsNumber: SMS_NUMBER, action: CONNECT_DEVICE_SMS })
       })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'returns a 200')
         t.equal(obj.block, false, 'not rate limited')
-        return client.postAsync('/check', { ip: TEST_IP3, email: 'test3@example.com', smsNumber: SMS_NUMBER, action: INVITE_USER_SMS })
+        return client.postAsync('/check', { ip: TEST_IP3, email: 'test3@example.com', smsNumber: SMS_NUMBER, action: CONNECT_DEVICE_SMS })
       })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'returns a 200')
@@ -85,7 +85,7 @@ test(
 
       // Reissue requests to verify that throttling is disabled
       .then(function(){
-        return client.postAsync('/check', { ip: TEST_IP, email: 'test4@example.com', smsNumber: SMS_NUMBER, action: INVITE_USER_SMS })
+        return client.postAsync('/check', { ip: TEST_IP, email: 'test4@example.com', smsNumber: SMS_NUMBER, action: CONNECT_DEVICE_SMS })
       })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'returns a 200')
@@ -100,20 +100,20 @@ test(
 )
 
 test(
-  '/check `inviteUserSms` by ip',
+  '/check `connectDeviceSms` by ip',
   function (t) {
 
     // Send requests until throttled
-    return client.postAsync('/check', { ip: TEST_IP4, email: 'test5@example.com', smsNumber: '1111111111', action: INVITE_USER_SMS })
+    return client.postAsync('/check', { ip: TEST_IP4, email: 'test5@example.com', smsNumber: '1111111111', action: CONNECT_DEVICE_SMS })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'returns a 200')
         t.equal(obj.block, false, 'not rate limited')
-        return client.postAsync('/check', { ip: TEST_IP4, email: 'test6@example.com', smsNumber: '2111111111', action: INVITE_USER_SMS })
+        return client.postAsync('/check', { ip: TEST_IP4, email: 'test6@example.com', smsNumber: '2111111111', action: CONNECT_DEVICE_SMS })
       })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'returns a 200')
         t.equal(obj.block, false, 'not rate limited')
-        return client.postAsync('/check', { ip: TEST_IP4, email: 'test8@example.com', smsNumber: '3111111111', action: INVITE_USER_SMS })
+        return client.postAsync('/check', { ip: TEST_IP4, email: 'test8@example.com', smsNumber: '3111111111', action: CONNECT_DEVICE_SMS })
       })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'returns a 200')
@@ -126,7 +126,7 @@ test(
 
       // Reissue requests to verify that throttling is disabled
       .then(function(){
-        return client.postAsync('/check', { ip: TEST_IP4, email: 'test9@example.com', smsNumber: '4111111111', action: INVITE_USER_SMS })
+        return client.postAsync('/check', { ip: TEST_IP4, email: 'test9@example.com', smsNumber: '4111111111', action: CONNECT_DEVICE_SMS })
       })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'returns a 200')

--- a/test/remote/too_many_sms.js
+++ b/test/remote/too_many_sms.js
@@ -11,7 +11,7 @@ var TEST_IP2 = '192.0.2.2'
 var TEST_IP3 = '192.0.2.3'
 var TEST_IP4 = '192.0.2.4'
 var CONNECT_DEVICE_SMS = 'connectDeviceSms'
-var SMS_NUMBER = '14071234567'
+var PHONE_NUMBER = '14071234567'
 
 var config = {
   listen: {
@@ -63,16 +63,16 @@ test(
   function (t) {
 
     // Send requests until throttled
-    return client.postAsync('/check', { ip: TEST_IP, email: 'test1@example.com', smsNumber: SMS_NUMBER, action: CONNECT_DEVICE_SMS })
+    return client.postAsync('/check', { ip: TEST_IP, email: 'test1@example.com', payload: { phoneNumber: PHONE_NUMBER }, action: CONNECT_DEVICE_SMS })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'returns a 200')
         t.equal(obj.block, false, 'not rate limited')
-        return client.postAsync('/check', { ip: TEST_IP2, email: 'test2@example.com', smsNumber: SMS_NUMBER, action: CONNECT_DEVICE_SMS })
+        return client.postAsync('/check', { ip: TEST_IP2, email: 'test2@example.com', payload: { phoneNumber: PHONE_NUMBER }, action: CONNECT_DEVICE_SMS })
       })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'returns a 200')
         t.equal(obj.block, false, 'not rate limited')
-        return client.postAsync('/check', { ip: TEST_IP3, email: 'test3@example.com', smsNumber: SMS_NUMBER, action: CONNECT_DEVICE_SMS })
+        return client.postAsync('/check', { ip: TEST_IP3, email: 'test3@example.com', payload: { phoneNumber: PHONE_NUMBER }, action: CONNECT_DEVICE_SMS })
       })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'returns a 200')
@@ -85,7 +85,7 @@ test(
 
       // Reissue requests to verify that throttling is disabled
       .then(function(){
-        return client.postAsync('/check', { ip: TEST_IP, email: 'test4@example.com', smsNumber: SMS_NUMBER, action: CONNECT_DEVICE_SMS })
+        return client.postAsync('/check', { ip: TEST_IP, email: 'test4@example.com', payload: { phoneNumber: PHONE_NUMBER }, action: CONNECT_DEVICE_SMS })
       })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'returns a 200')
@@ -104,16 +104,16 @@ test(
   function (t) {
 
     // Send requests until throttled
-    return client.postAsync('/check', { ip: TEST_IP4, email: 'test5@example.com', smsNumber: '1111111111', action: CONNECT_DEVICE_SMS })
+    return client.postAsync('/check', { ip: TEST_IP4, email: 'test5@example.com', payload: { phoneNumber: '1111111111' }, action: CONNECT_DEVICE_SMS })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'returns a 200')
         t.equal(obj.block, false, 'not rate limited')
-        return client.postAsync('/check', { ip: TEST_IP4, email: 'test6@example.com', smsNumber: '2111111111', action: CONNECT_DEVICE_SMS })
+        return client.postAsync('/check', { ip: TEST_IP4, email: 'test6@example.com', payload: { phoneNumber: '2111111111' }, action: CONNECT_DEVICE_SMS })
       })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'returns a 200')
         t.equal(obj.block, false, 'not rate limited')
-        return client.postAsync('/check', { ip: TEST_IP4, email: 'test8@example.com', smsNumber: '3111111111', action: CONNECT_DEVICE_SMS })
+        return client.postAsync('/check', { ip: TEST_IP4, email: 'test8@example.com', payload: { phoneNumber: '3111111111' }, action: CONNECT_DEVICE_SMS })
       })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'returns a 200')
@@ -126,7 +126,7 @@ test(
 
       // Reissue requests to verify that throttling is disabled
       .then(function(){
-        return client.postAsync('/check', { ip: TEST_IP4, email: 'test9@example.com', smsNumber: '4111111111', action: CONNECT_DEVICE_SMS })
+        return client.postAsync('/check', { ip: TEST_IP4, email: 'test9@example.com', payload: { phoneNumber: '4111111111' }, action: CONNECT_DEVICE_SMS })
       })
       .spread(function(req, res, obj){
         t.equal(res.statusCode, 200, 'returns a 200')


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-customs-server/issues/160

This PR adds the following support to the custom's server:

- [x] Rate limit sending X amount of sms to a specific number
- [x] Rate limit an ip sending X total amount of sms

Connects with https://github.com/mozilla/fxa-features/issues/53, https://github.com/mozilla/fxa-auth-server/issues/1628