### PR TITLE
fix(timers): Unref all the update-polling timers.

### DIFF
--- a/lib/allowed_email_domains.js
+++ b/lib/allowed_email_domains.js
@@ -48,6 +48,7 @@ module.exports = function (config, mc, log) {
   AllowedEmailDomains.prototype.pollForUpdates = function () {
     this.stopPolling()
     pollInterval = setInterval(this.refresh.bind(this), config.updatePollIntervalSeconds * 1000)
+    pollInterval.unref()
   }
 
   AllowedEmailDomains.prototype.stopPolling = function () {

--- a/lib/allowed_ips.js
+++ b/lib/allowed_ips.js
@@ -44,6 +44,7 @@ module.exports = function (config, mc, log) {
   AllowedIPs.prototype.pollForUpdates = function () {
     this.stopPolling()
     pollInterval = setInterval(this.refresh.bind(this), config.updatePollIntervalSeconds * 1000)
+    pollInterval.unref()
   }
 
   AllowedIPs.prototype.stopPolling = function () {

--- a/lib/bans/sqs.js
+++ b/lib/bans/sqs.js
@@ -37,6 +37,7 @@ module.exports = function (log) {
             // unacceptable! this aws lib will call the callback
             // more than once with different errors.
             errTimer = setTimeout(this.fetch.bind(this, url), 2000)
+            errTimer.unref()
           }
           return
         }

--- a/lib/ip_blocklist.js
+++ b/lib/ip_blocklist.js
@@ -164,6 +164,7 @@ module.exports = function (log, config) {
   IPBlocklist.prototype.pollForUpdates = function () {
     this.stopPolling()
     this.pollInterval = setInterval(this.refresh.bind(this), config.ipBlocklist.updatePollInterval * 1000)
+    this.pollInterval.unref()
   }
 
   IPBlocklist.prototype.stopPolling = function () {

--- a/lib/limits.js
+++ b/lib/limits.js
@@ -60,6 +60,7 @@ module.exports = function (config, mc, log) {
   Limits.prototype.pollForUpdates = function () {
     this.stopPolling()
     pollInterval = setInterval(this.refresh.bind(this), config.updatePollIntervalSeconds * 1000)
+    pollInterval.unref()
   }
 
   Limits.prototype.stopPolling = function () {

--- a/lib/requestChecks.js
+++ b/lib/requestChecks.js
@@ -44,6 +44,7 @@ module.exports = function (config, mc, log) {
   RequestChecks.prototype.pollForUpdates = function () {
     this.stopPolling()
     pollInterval = setInterval(this.refresh.bind(this), config.updatePollIntervalSeconds * 1000)
+    pollInterval.unref()
   }
 
   RequestChecks.prototype.stopPolling = function () {


### PR DESCRIPTION
These timers are all just for background polling for updates, they don't need to keep the event-loop alive.  Unref them.