### PR TITLE
chore(package): Use ip-rep service client with keepalive enabled

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2138,9 +2138,9 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.3.tgz"
     },
     "ip-reputation-js-client": {
-      "version": "2.0.1",
-      "from": "ip-reputation-js-client@2.0.1",
-      "resolved": "https://registry.npmjs.org/ip-reputation-js-client/-/ip-reputation-js-client-2.0.1.tgz",
+      "version": "2.1.1",
+      "from": "ip-reputation-js-client@2.1.1",
+      "resolved": "https://registry.npmjs.org/ip-reputation-js-client/-/ip-reputation-js-client-2.1.1.tgz",
       "dependencies": {
         "bluebird": {
           "version": "3.4.6",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "csv-parse": "1.0.4",
     "deep-equal": "1.0.1",
     "ip": "1.1.3",
-    "ip-reputation-js-client": "2.0.1",
+    "ip-reputation-js-client": "2.1.1",
     "lodash.merge": "4.6.0",
     "lodash.isequal": "4.5.0",
     "memcached": "2.2.1",


### PR DESCRIPTION
Bump IP Reputation JS client to version 2.1.1 which has keepalive enabled.

This should help fix some of the TCP RSTs and timeouts jrgm and I saw when we enabled a canary instance in prod last week.