### PR TITLE
feat(emails): Add `createEmail` to email sending endpoints

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -37,6 +37,7 @@ const ACCOUNT_STATUS_ACTION = {
 // us look like spammers if abused.
 const EMAIL_SENDING_ACTION = {
   accountCreate: true,
+  createEmail: true,
   recoveryEmailResendCode: true,
   passwordForgotSendCode: true,
   passwordForgotResendCode: true,


### PR DESCRIPTION
This PR adds rate-limiting to all endpoints that send emails for the add secondary email feature. It is a one liner because we reuse the verify code and resend code endpoints in add secondary emails. The only other endpoint that sends an email is the create email operation.

Fixes #180 

@vladikoff r?