### PR TITLE
feat(actions): add consumeSigninCode as an ACCOUNT_ACCESS_ACTION

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -16,7 +16,8 @@ const PASSWORD_CHECKING_ACTION = {
 // but if you're doing it a lot, you're probably a baddie.
 const CODE_VERIFYING_ACTION = {
   recoveryEmailVerifyCode: true,
-  passwordForgotVerifyCode: true
+  passwordForgotVerifyCode: true,
+  signinCode: true
 }
 
 // Actions that, if allowed, would allow an attacker

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -16,8 +16,7 @@ const PASSWORD_CHECKING_ACTION = {
 // but if you're doing it a lot, you're probably a baddie.
 const CODE_VERIFYING_ACTION = {
   recoveryEmailVerifyCode: true,
-  passwordForgotVerifyCode: true,
-  signinCode: true
+  passwordForgotVerifyCode: true
 }
 
 // Actions that, if allowed, would allow an attacker
@@ -51,6 +50,12 @@ const SMS_SENDING_ACTION = {
   connectDeviceSms: true
 }
 
+// Actions that may grant access to an account but
+// are not associated with an email address or uid.
+const ACCOUNT_ACCESS_ACTION = new Set([
+  'consumeSigninCode'
+])
+
 module.exports = {
 
   isPasswordCheckingAction: function (action) {
@@ -71,5 +76,9 @@ module.exports = {
 
   isSmsSendingAction: function (action) {
     return SMS_SENDING_ACTION[action]
+  },
+
+  isAccountAccessAction (action) {
+    return ACCOUNT_ACCESS_ACTION.has(action)
   }
 }

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -146,6 +146,12 @@ module.exports = function (fs, path, url, convict) {
         default: 5,
         format: 'nat',
         env: 'MAX_ACCOUNT_STATUS_CHECK'
+      },
+      maxAccountAccess: {
+        doc: 'Number of account access actions within ipRateLimitIntervalSeconds before throttling',
+        default: 5,
+        format: 'nat',
+        env: 'MAX_ACCOUNT_ACCESS'
       }
     },
     memcache: {

--- a/lib/settings/limits.js
+++ b/lib/settings/limits.js
@@ -38,6 +38,7 @@ module.exports = (config, Settings, log) => {
       this.maxSms = settings.smsRateLimit.maxSms
       this.smsRateLimitIntervalSeconds = this.smsRateLimit.limitIntervalSeconds
       this.smsRateLimitIntervalMs = this.smsRateLimitIntervalSeconds * 1000
+      this.maxAccountAccess = settings.maxAccountAccess
 
       return this
     }

--- a/test/remote/check_ip_only_tests.js
+++ b/test/remote/check_ip_only_tests.js
@@ -1,0 +1,69 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+'use strict'
+
+const memcached = require('../memcache-helper')
+const restify = require('restify')
+const test = require('tap').test
+const TestServer = require('../test_server')
+
+const IP = '192.168.1.1'
+const ACTION = 'wibble'
+
+const config = {
+  listen: {
+    port: 7000
+  }
+}
+
+const testServer = new TestServer(config)
+
+const client = restify.createJsonClient({
+  url: 'http://127.0.0.1:' + config.listen.port
+})
+
+test('startup', t => {
+  testServer.start(err => {
+    t.type(testServer.server, 'object', 'testServer.server should be an object')
+    t.notOk(err, 'testServer.start should not return an error')
+    t.end()
+  })
+})
+
+test('clear everything', t => {
+  memcached.clearEverything(err => {
+    t.notOk(err, 'memcached.clearEverything should not return an error')
+    t.end()
+  })
+})
+
+test('with ip and action', t => {
+  client.post('/checkIpOnly', { ip: IP, action: ACTION }, (err, req, res, obj) => {
+    t.notOk(err, '/checkIpOnly should not return an error')
+    t.equal(res.statusCode, 200, '/checkIpOnly should return a 200 response')
+    t.type(obj, 'object', '/checkIpOnly should return an object')
+    t.end()
+  })
+})
+
+test('missing action', t => {
+  client.post('/checkIpOnly', { ip: IP }, (err, req, res, obj) => {
+    t.equal(res.statusCode, 400, '/checkIpOnly should return a 400 response')
+    t.end()
+  })
+})
+
+test('missing ip', t => {
+  client.post('/checkIpOnly', { action: ACTION }, (err, req, res, obj) => {
+    t.equal(res.statusCode, 400, '/checkIpOnly should return a 400 response')
+    t.end()
+  })
+})
+
+test('teardown', t => {
+  testServer.stop()
+  t.equal(testServer.server.killed, true, 'testServer.server.killed should be true')
+  t.end()
+})
+

--- a/test/remote/ip_blocklist_disable.js
+++ b/test/remote/ip_blocklist_disable.js
@@ -10,6 +10,7 @@ var mcHelper = require('../memcache-helper')
 var TEST_EMAIL = 'test@example.com'
 var ACTION = 'dummyAction'
 var BLOCK_IP = '1.93.0.224'
+const ENDPOINTS = [ '/check', '/checkIpOnly' ]
 
 process.env.IP_BLOCKLIST_ENABLE = false
 
@@ -49,17 +50,16 @@ var client = restify.createJsonClient({
 
 Promise.promisifyAll(client, {multiArgs: true})
 
-test(
-  'ignore ip from ip blocklist',
-  function (t) {
-    client.postAsync('/check', {ip: BLOCK_IP, email: TEST_EMAIL, action: ACTION},
+ENDPOINTS.forEach(endpoint => {
+  test(`${endpoint} ignore ip from ip blocklist`, t => {
+    client.postAsync(endpoint, {ip: BLOCK_IP, email: TEST_EMAIL, action: ACTION},
       function (err, req, res, obj) {
         t.equal(obj.block, false, 'request is blocked')
         t.end()
       }
     )
-  }
-)
+  })
+})
 
 test(
   'teardown',

--- a/test/remote/ip_blocklist_tests.js
+++ b/test/remote/ip_blocklist_tests.js
@@ -14,6 +14,7 @@ var LOG_ONLY_BOTH_LIST_IP = '1.93.0.225'
 var LOG_ONLY_IP = '86.75.30.9'
 var BLOCK_IP_INRANGE = '0.1.0.0'
 var VALID_IP = '3.0.0.0'
+const ENDPOINTS = [ '/check', '/checkIpOnly' ]
 
 process.env.IP_BLOCKLIST_ENABLE = true
 process.env.IP_BLOCKLIST_FILES = [
@@ -59,65 +60,52 @@ var client = restify.createJsonClient({
 
 Promise.promisifyAll(client, {multiArgs: true})
 
-test(
-  'block ip from ip blocklist',
-  function (t) {
-    client.postAsync('/check', {ip: BLOCK_IP, email: TEST_EMAIL, action: ACTION},
+ENDPOINTS.forEach(endpoint => {
+  test(`${endpoint} block ip from ip blocklist`, t => {
+    client.postAsync(endpoint, {ip: BLOCK_IP, email: TEST_EMAIL, action: ACTION},
       function (err, req, res, obj) {
         t.equal(obj.block, true, 'request is blocked')
         t.end()
       }
     )
-  }
-)
+  })
 
-test(
-  'block ip in range of blocklist',
-  function (t) {
-    client.postAsync('/check', {ip: BLOCK_IP_INRANGE, email: TEST_EMAIL, action: ACTION},
+  test(`${endpoint} block ip in range of blocklist`, t => {
+    client.postAsync(endpoint, {ip: BLOCK_IP_INRANGE, email: TEST_EMAIL, action: ACTION},
       function (err, req, res, obj) {
         t.equal(obj.block, true, 'request is blocked')
         t.end()
       }
     )
-  }
-)
+  })
 
-test(
-  'do not block ip not in range blocklist',
-  function (t) {
-    client.postAsync('/check', {ip: VALID_IP, email: TEST_EMAIL, action: ACTION},
+  test(`${endpoint} do not block ip not in range blocklist`, t => {
+    client.postAsync(endpoint, {ip: VALID_IP, email: TEST_EMAIL, action: ACTION},
       function (err, req, res, obj) {
         t.equal(obj.block, false, 'request is not blocked')
         t.end()
       }
     )
-  }
-)
+  })
 
-test(
-  'should log only on hit from logOnly list',
-  function (t) {
-    client.postAsync('/check', {ip: LOG_ONLY_IP, email: TEST_EMAIL, action: ACTION},
+  test(`${endpoint} should log only on hit from logOnly list`, t => {
+    client.postAsync(endpoint, {ip: LOG_ONLY_IP, email: TEST_EMAIL, action: ACTION},
       function (err, req, res, obj) {
         t.equal(obj.block, false, 'request is not blocked')
         t.end()
       }
     )
-  }
-)
+  })
 
-test(
-  'should block request on hit form logOnly and blocklist',
-  function (t) {
-    client.postAsync('/check', {ip: LOG_ONLY_BOTH_LIST_IP, email: TEST_EMAIL, action: ACTION},
+  test(`${endpoint} should block request on hit from logOnly and blocklist`, t => {
+    client.postAsync(endpoint, {ip: LOG_ONLY_BOTH_LIST_IP, email: TEST_EMAIL, action: ACTION},
       function (err, req, res, obj) {
         t.equal(obj.block, true, 'request is blocked')
         t.end()
       }
     )
-  }
-)
+  })
+})
 
 test(
   'teardown',

--- a/test/remote/too_many_signin_codes.js
+++ b/test/remote/too_many_signin_codes.js
@@ -1,14 +1,16 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
-const test = require('tap').test
-const TestServer = require('../test_server')
+'use strict'
+
+const memcached = require('../memcache-helper')
 const Promise = require('bluebird')
 const restify = Promise.promisifyAll(require('restify'))
-const memcached = require('../memcache-helper')
+const test = require('tap').test
+const TestServer = require('../test_server')
 
-const TEST_IP = '192.0.2.1'
-const VERIFY_CODE = 'signinCode'
+const IP = '192.168.1.2'
+const ACTION = 'consumeSigninCode'
 
 const config = {
   listen: {
@@ -16,8 +18,7 @@ const config = {
   }
 }
 
-process.env.MAX_VERIFY_CODES = 2
-process.env.RATE_LIMIT_INTERVAL_SECONDS = 1
+process.env.MAX_ACCOUNT_ACCESS = 2
 process.env.IP_RATE_LIMIT_INTERVAL_SECONDS = 1
 process.env.IP_RATE_LIMIT_BAN_DURATION_SECONDS = 1
 
@@ -31,130 +32,58 @@ Promise.promisifyAll(client, { multiArgs: true })
 
 test('startup', t => {
   testServer.start(err => {
-    t.type(testServer.server, 'object', 'test server was started')
-    t.notOk(err, 'no errors were returned')
+    t.type(testServer.server, 'object', 'testServer.server should be an object')
+    t.notOk(err, 'testServer.start should not return an error')
     t.end()
   })
 })
 
 test('clear everything', t => {
   memcached.clearEverything(err => {
-    t.notOk(err, 'no errors were returned')
+    t.notOk(err, 'memcached.clearEverything should not return an error')
     t.end()
   })
 })
 
-test('/check `signinCode` by email', t => {
-  return client.postAsync('/check', {
-    ip: TEST_IP,
-    email: 'foo@example.com',
-    action: VERIFY_CODE
+test('/checkIpOnly `signinCode`', t => {
+  return client.postAsync('/checkIpOnly', {
+    ip: IP,
+    action: ACTION
   })
     .spread((req, res, obj) => {
-      t.equal(res.statusCode, 200, '/check should return a 200 response')
-      t.equal(obj.block, false, '/check should return block:false')
+      t.equal(res.statusCode, 200, '/checkIpOnly should return a 200 response')
+      t.equal(obj.block, false, '/checkIpOnly should return block:false')
 
-      return client.postAsync('/check', {
-        ip: TEST_IP,
-        email: 'foo@example.com',
-        action: VERIFY_CODE
+      return client.postAsync('/checkIpOnly', {
+        ip: IP,
+        action: ACTION
       })
     })
     .spread((req, res, obj) => {
-      t.equal(res.statusCode, 200, '/check should return a 200 response')
-      t.equal(obj.block, false, '/check should return block:false')
+      t.equal(res.statusCode, 200, '/checkIpOnly should return a 200 response')
+      t.equal(obj.block, false, '/checkIpOnly should return block:false')
 
-      return client.postAsync('/check', {
-        ip: TEST_IP,
-        email: 'foo@example.com',
-        action: VERIFY_CODE
+      return client.postAsync('/checkIpOnly', {
+        ip: IP,
+        action: ACTION
       })
     })
     .spread((req, res, obj) => {
-      t.equal(res.statusCode, 200, '/check should return a 200 response')
-      t.equal(obj.block, true, '/check should return block:true')
-      t.equal(obj.retryAfter, 1, '/check should return retryAfter:1')
+      t.equal(res.statusCode, 200, '/checkIpOnly should return a 200 response')
+      t.equal(obj.block, true, '/checkIpOnly should return block:true')
+      t.equal(obj.retryAfter, 1, '/checkIpOnly should return retryAfter:1')
 
       return Promise.delay(1001)
     })
     .then(() => {
-      return client.postAsync('/check', {
-        ip: TEST_IP,
-        email: 'foo@example.com',
-        action: VERIFY_CODE
+      return client.postAsync('/checkIpOnly', {
+        ip: IP,
+        action: ACTION
       })
     })
     .spread((req, res, obj) => {
-      t.equal(res.statusCode, 200, '/check should return a 200 response')
-      t.equal(obj.block, false, '/check should return block:false')
-      t.end()
-    })
-    .catch(err => {
-      t.fail(err)
-      t.end()
-    })
-})
-
-test('clear everything', t => {
-  memcached.clearEverything(err => {
-    t.notOk(err, 'no errors were returned')
-    t.end()
-  })
-})
-
-test('/check `signinCode` by ip', t => {
-  return client.postAsync('/check', {
-    ip: TEST_IP,
-    email: 'bar@example.com',
-    action: VERIFY_CODE
-  })
-    .spread((req, res, obj) => {
-      t.equal(res.statusCode, 200, '/check should return a 200 response')
-      t.equal(obj.block, false, '/check should return block:false')
-
-      return client.postAsync('/check', {
-        ip: TEST_IP,
-        email: 'baz@example.com',
-        action: VERIFY_CODE
-      })
-    })
-    .spread((req, res, obj) => {
-      t.equal(res.statusCode, 200, '/check should return a 200 response')
-      t.equal(obj.block, false, '/check should return block:false')
-
-      return client.postAsync('/check', {
-        ip: TEST_IP,
-        email: 'bar@example.com',
-        action: VERIFY_CODE
-      })
-    })
-    .spread((req, res, obj) => {
-      t.equal(res.statusCode, 200, '/check should return a 200 response')
-      t.equal(obj.block, false, '/check should return block:false')
-
-      return client.postAsync('/check', {
-        ip: TEST_IP,
-        email: 'qux@example.com',
-        action: VERIFY_CODE
-      })
-    })
-    .spread((req, res, obj) => {
-      t.equal(res.statusCode, 200, '/check should return a 200 response')
-      t.equal(obj.block, true, '/check should return block:true')
-      t.equal(obj.retryAfter, 1, '/check should return retryAfter:1')
-
-      return Promise.delay(1001)
-    })
-    .then(() => {
-      return client.postAsync('/check', {
-        ip: TEST_IP,
-        email: 'qux@example.com',
-        action: VERIFY_CODE
-      })
-    })
-    .spread((req, res, obj) => {
-      t.equal(res.statusCode, 200, '/check should return a 200 response')
-      t.equal(obj.block, false, '/check should return block:false')
+      t.equal(res.statusCode, 200, '/checkIpOnly should return a 200 response')
+      t.equal(obj.block, false, '/checkIpOnly should return block:false')
       t.end()
     })
     .catch(err => {
@@ -165,7 +94,7 @@ test('/check `signinCode` by ip', t => {
 
 test('teardown', t => {
   testServer.stop()
-  t.equal(testServer.server.killed, true, 'test server has been killed')
+  t.equal(testServer.server.killed, true, 'testServer.server.killed should be true')
   t.end()
 })
 

--- a/test/remote/too_many_signin_codes.js
+++ b/test/remote/too_many_signin_codes.js
@@ -1,0 +1,171 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+const test = require('tap').test
+const TestServer = require('../test_server')
+const Promise = require('bluebird')
+const restify = Promise.promisifyAll(require('restify'))
+const memcached = require('../memcache-helper')
+
+const TEST_IP = '192.0.2.1'
+const VERIFY_CODE = 'signinCode'
+
+const config = {
+  listen: {
+    port: 7000
+  }
+}
+
+process.env.MAX_VERIFY_CODES = 2
+process.env.RATE_LIMIT_INTERVAL_SECONDS = 1
+process.env.IP_RATE_LIMIT_INTERVAL_SECONDS = 1
+process.env.IP_RATE_LIMIT_BAN_DURATION_SECONDS = 1
+
+const testServer = new TestServer(config)
+
+const client = restify.createJsonClient({
+  url: 'http://127.0.0.1:' + config.listen.port
+})
+
+Promise.promisifyAll(client, { multiArgs: true })
+
+test('startup', t => {
+  testServer.start(err => {
+    t.type(testServer.server, 'object', 'test server was started')
+    t.notOk(err, 'no errors were returned')
+    t.end()
+  })
+})
+
+test('clear everything', t => {
+  memcached.clearEverything(err => {
+    t.notOk(err, 'no errors were returned')
+    t.end()
+  })
+})
+
+test('/check `signinCode` by email', t => {
+  return client.postAsync('/check', {
+    ip: TEST_IP,
+    email: 'foo@example.com',
+    action: VERIFY_CODE
+  })
+    .spread((req, res, obj) => {
+      t.equal(res.statusCode, 200, '/check should return a 200 response')
+      t.equal(obj.block, false, '/check should return block:false')
+
+      return client.postAsync('/check', {
+        ip: TEST_IP,
+        email: 'foo@example.com',
+        action: VERIFY_CODE
+      })
+    })
+    .spread((req, res, obj) => {
+      t.equal(res.statusCode, 200, '/check should return a 200 response')
+      t.equal(obj.block, false, '/check should return block:false')
+
+      return client.postAsync('/check', {
+        ip: TEST_IP,
+        email: 'foo@example.com',
+        action: VERIFY_CODE
+      })
+    })
+    .spread((req, res, obj) => {
+      t.equal(res.statusCode, 200, '/check should return a 200 response')
+      t.equal(obj.block, true, '/check should return block:true')
+      t.equal(obj.retryAfter, 1, '/check should return retryAfter:1')
+
+      return Promise.delay(1001)
+    })
+    .then(() => {
+      return client.postAsync('/check', {
+        ip: TEST_IP,
+        email: 'foo@example.com',
+        action: VERIFY_CODE
+      })
+    })
+    .spread((req, res, obj) => {
+      t.equal(res.statusCode, 200, '/check should return a 200 response')
+      t.equal(obj.block, false, '/check should return block:false')
+      t.end()
+    })
+    .catch(err => {
+      t.fail(err)
+      t.end()
+    })
+})
+
+test('clear everything', t => {
+  memcached.clearEverything(err => {
+    t.notOk(err, 'no errors were returned')
+    t.end()
+  })
+})
+
+test('/check `signinCode` by ip', t => {
+  return client.postAsync('/check', {
+    ip: TEST_IP,
+    email: 'bar@example.com',
+    action: VERIFY_CODE
+  })
+    .spread((req, res, obj) => {
+      t.equal(res.statusCode, 200, '/check should return a 200 response')
+      t.equal(obj.block, false, '/check should return block:false')
+
+      return client.postAsync('/check', {
+        ip: TEST_IP,
+        email: 'baz@example.com',
+        action: VERIFY_CODE
+      })
+    })
+    .spread((req, res, obj) => {
+      t.equal(res.statusCode, 200, '/check should return a 200 response')
+      t.equal(obj.block, false, '/check should return block:false')
+
+      return client.postAsync('/check', {
+        ip: TEST_IP,
+        email: 'bar@example.com',
+        action: VERIFY_CODE
+      })
+    })
+    .spread((req, res, obj) => {
+      t.equal(res.statusCode, 200, '/check should return a 200 response')
+      t.equal(obj.block, false, '/check should return block:false')
+
+      return client.postAsync('/check', {
+        ip: TEST_IP,
+        email: 'qux@example.com',
+        action: VERIFY_CODE
+      })
+    })
+    .spread((req, res, obj) => {
+      t.equal(res.statusCode, 200, '/check should return a 200 response')
+      t.equal(obj.block, true, '/check should return block:true')
+      t.equal(obj.retryAfter, 1, '/check should return retryAfter:1')
+
+      return Promise.delay(1001)
+    })
+    .then(() => {
+      return client.postAsync('/check', {
+        ip: TEST_IP,
+        email: 'qux@example.com',
+        action: VERIFY_CODE
+      })
+    })
+    .spread((req, res, obj) => {
+      t.equal(res.statusCode, 200, '/check should return a 200 response')
+      t.equal(obj.block, false, '/check should return block:false')
+      t.end()
+    })
+    .catch(err => {
+      t.fail(err)
+      t.end()
+    })
+})
+
+test('teardown', t => {
+  testServer.stop()
+  t.equal(testServer.server.killed, true, 'test server has been killed')
+  t.end()
+})
+


### PR DESCRIPTION
Fixes #201.

* Adds a new endpoint `/checkIpOnly` that rate-limits purely against an IP address, with no requirement for an email address or a uid.

* Adds a new class of action that I'm calling `ACCOUNT_ACCESS_ACTION`, with one eye on phase 4 of connect-another-device. I needed a new action because I have no email address to rate-limit against, so I can't use `CODE_VERIFYING_ACTION` for instance.

* Refactors some of the common code to make `email` an optional parameter. Doing this necessitated changing the order of some arguments and returned promises, but I think I covered all the calling code in my changes.

The intention is for the proposed auth server endpoint for consuming signinCodes (see mozilla/fxa-auth-server#1882) to hit `/checkIpOnly` with `{"action":"consumeSigninCode"}` and the IP address.

This is the first time I've worked in the customs server and there's a fair bit of stuff I still don't understand, so this PR may have a little way to go. I'll add inline comments to call out the bits I'm most unsure of.

@mozilla/fxa-devs r?
