### PR TITLE
fix(iprecord): clear ip record rate limit after whitelisting

### DIFF
--- a/lib/ip_record.js
+++ b/lib/ip_record.js
@@ -30,6 +30,10 @@ module.exports = function (limits, now) {
     return rec
   }
 
+  IpRecord.prototype.clear = function () {
+    this.rl = null
+  }
+
   IpRecord.prototype.getMinLifetimeMS = function () {
     return Math.max(
       limits.blockIntervalMs,

--- a/lib/server.js
+++ b/lib/server.js
@@ -141,18 +141,25 @@ module.exports = function createServer(config, log) {
     // that we won't block. These are typically for Mozilla QA purposes.
     // They should be checked after everything else so as not to pay the
     // overhead of checking the many requests that are *not* QA-related.
-    if (result.block || result.suspect) {
-      if (ip in allowedIPs.ips || (email && allowedEmailDomains.isAllowed(email))) {
-        log.info({
-          op: 'request.check.allowed',
-          ip: ip,
-          block: result.block,
-          suspect: result.suspect
-        })
-        result.block = false
-        result.suspect = false
-      }
+    if ((result.block || result.suspect) && isWhitelisted(ip, email)) {
+      log.info({
+        op: 'request.check.allowed',
+        ip: ip,
+        block: result.block,
+        suspect: result.suspect
+      })
+
+      result.block = false
+      result.suspect = false
+
+      return true
     }
+
+    return false
+  }
+
+  function isWhitelisted (ip, email) {
+    return ip in allowedIPs.ips || (email && allowedEmailDomains.isAllowed(email))
   }
 
   function optionallyReportIp (result, ip, action) {
@@ -196,7 +203,7 @@ module.exports = function createServer(config, log) {
       fetchRecords(ip, email, phoneNumber)
         .spread(
           function (ipRecord, reputation, emailRecord, ipEmailRecord, smsRecord) {
-            if (ipRecord.isBlocked()) {
+            if (ipRecord.isBlocked() && ! isWhitelisted(ip, email)) {
               // a blocked ip should just be ignored completely
               // it's malicious, it shouldn't penalize emails or allow
               // (most) escape hatches. just abort!
@@ -253,24 +260,28 @@ module.exports = function createServer(config, log) {
               blockReason = blockReasons.IP_BAD_REPUTATION
             }
 
+            // Must be defined before the call to `allowWhitelisted`,
+            // because that function modifies `result` in-place.
+            const result = {
+              block: block,
+              blockReason: blockReason,
+              retryAfter: retryAfter,
+              unblock: canUnblock,
+              suspect: suspect
+            }
+
+            if (allowWhitelisted(result, ip, email)) {
+              // Prevent white-listed email addresses from blocking
+              // subsequent requests to /checkIpOnly
+              ipRecord.clear()
+            }
+
             return setRecords(ip, ipRecord, email, emailRecord, ipEmailRecord, phoneNumber, smsRecord)
-              .then(
-                function () {
-                  return {
-                    block: block,
-                    blockReason: blockReason,
-                    retryAfter: retryAfter,
-                    unblock: canUnblock,
-                    suspect: suspect
-                  }
-                }
-              )
+              .then(() => result)
           }
         )
         .then(
           function (result) {
-            allowWhitelisted(result, ip, email)
-
             log.info({
               op: 'request.check',
               email: email,


### PR DESCRIPTION
Fixes #205.

Whitelisted email addresses were setting the rate limit flag on the cached ip record. This meant that `/checkIpOnly` was being rate-limited for earlier actions performed by whitelisted email addresses, because it didn't have an email address of its own to whitelist against.

This PR fixes that by clearing `IpRecord::rl` after whitelisting in `/check`.  To get there it required a little bit of jiggling about of the surrounding code. I tried to do that in the least disruptive way, because this is the customs server and I have no idea what I'm doing. :smile:

@mozilla/fxa-devs r?