### PR TITLE
fix(newrelic): be clear that newrelic must be required first

### DIFF
--- a/bin/customs_server.js
+++ b/bin/customs_server.js
@@ -4,6 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// This MUST be the first require in the program.
 // Only `require()` the newrelic module if explicity enabled.
 // If required, modules will be instrumented.
 require('../lib/newrelic')()


### PR DESCRIPTION
Just adding a comment to try to future proof against including other modules before newrelic (which would mean they would not be instrumented)

r? - @vladikoff 