### PR TITLE
fix(test): #228 Start memcached as part of 'npm test'

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ Clone the git repository and install dependencies:
     cd fxa-customs-server
     npm install
 
-You'll also need to [install memcached](http://www.memcached.org/downloads),
-otherwise all requests will be blocked.
-By default, the customs server tries to connect to memcached
-using port `11211` on `127.0.0.1`.
-You can specify a different port and IP address
-using the `memcache.address` configuration setting
-or the `MEMCACHE_ADDRESS` environment variable.
+Install memcached
+
+    You'll need to [install memcached](http://www.memcached.org/downloads),
+    otherwise all requests will be blocked.
+    By default, the customs server tries to connect to memcached
+    using port `11211` on `127.0.0.1`.
+    You can specify a different port and IP address
+    using the `memcache.address` configuration setting
+    or the `MEMCACHE_ADDRESS` environment variable.
 
 To start the server, run:
 
@@ -39,12 +41,6 @@ To run the customs server via Docker:
 Run tests with:
 
     npm test
-
-On Mac OS X, memcached must be manually started for the tests to run.
-
-    memcached &
-    npm test
-
 
 To run tests via Docker:
 

--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -11,4 +11,13 @@ if test "$NO_COVERAGE" = ""; then
   cov="--coverage --cov"
 fi
 
+if ! echo stats | nc localhost 11211 | grep -q 'STAT'; then
+  memcached &
+  MC=$!
+fi
+
 tap test/local test/remote $cov
+
+if [[ $MC ]]; then
+  kill $MC
+fi

--- a/test/memcache-helper.js
+++ b/test/memcache-helper.js
@@ -10,8 +10,7 @@ P.promisifyAll(Memcached.prototype)
 
 var config = {
   memcache: {
-    host: '127.0.0.1',
-    port: '11211'
+    address: '127.0.0.1:11211',
   },
   limits: {
     blockIntervalSeconds: 1,


### PR DESCRIPTION
Have added the lines to start memcached, not checking if it is running already as it does nothing if it is already running. spawnSync makes it waiting forever so i am using spawn only.
