### PR TITLE
feat(totp): add totp rate limits

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -279,6 +279,37 @@ module.exports = function (fs, path, url, convict) {
       default: '',
       format: 'String',
       env: 'SENTRY_DSN'
+    },
+    userDefinedRateLimitRules: {
+      totpCodeRules: {
+        actions: {
+          doc: 'Array of actions that this rule should be applied to',
+          default: [
+            'verifyTotpCode',
+          ],
+          format: Array
+        },
+        limits: {
+          max: {
+            doc: 'max actions during `period` that can occur before rate limit is applied',
+            format: 'nat',
+            default: 2,
+            env: 'TOTP_CODE_RULE_MAX'
+          },
+          periodMs: {
+            doc: 'period needed before rate limit is reset',
+            format: 'duration',
+            default: '30 seconds',
+            env: 'TOTP_CODE_RULE_PERIOD_MS'
+          },
+          rateLimitIntervalMs: {
+            doc: 'how long rate limit is applied',
+            format: 'duration',
+            default: '30 seconds',
+            env: 'TOTP_CODE_RULE_LIMIT_INTERVAL_MS'
+          }
+        }
+      }
     }
   })
 

--- a/lib/record.js
+++ b/lib/record.js
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+class Record {
+  constructor(object, config, now = Date.now) {
+    object = object || {}
+    this.rl = object.rl       // timestamp when the account was rate-limited
+    this.hits = object.hits || [] // timestamps when last hit occurred
+    this.limits = config.limits
+    this.actions = config.actions
+    this.now = now
+  }
+
+  getMinLifetimeMS() {
+    return this.limits.rateLimitIntervalMs
+  }
+
+  isOverLimit() {
+    this.trimHits(this.now())
+    return this.hits.length > this.limits.max
+  }
+
+  trimHits(now) {
+    if (this.hits.length === 0) {
+      return
+    }
+    // hits is naturally ordered from oldest to newest
+    // and we only need to keep up to hit + 1
+    const periodMs = this.limits.periodMs
+    const max = this.limits.max
+
+    let i = this.hits.length - 1
+    let n = 0
+    let hit = this.hits[i]
+    while (hit > (now - periodMs) && n <= max) {
+      hit = this.hits[--i]
+      n++
+    }
+    this.hits = this.hits.slice(i + 1)
+  }
+
+  addHit() {
+    this.hits.push(this.now())
+  }
+
+  isRateLimited() {
+    return !!(this.rl && (this.now() - this.rl < this.limits.rateLimitIntervalMs))
+  }
+
+  rateLimit() {
+    this.rl = this.now()
+    this.hits = []
+  }
+
+  retryAfter() {
+    const rateLimitIntervalMs = this.limits.rateLimitIntervalMs
+    const rateLimitAfter = Math.ceil(((this.rl || 0) + rateLimitIntervalMs - this.now()) / 1000)
+    return Math.max(0, rateLimitAfter)
+  }
+
+  update(action) {
+    if (this.actions.indexOf(action) > -1) {
+      if (this.isRateLimited()) {
+        return this.retryAfter()
+      }
+
+      this.addHit()
+
+      if (this.isOverLimit()) {
+        this.rateLimit()
+        return this.retryAfter()
+      }
+    }
+    return 0
+  }
+}
+
+module.exports = Record

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const crypto = require('crypto')
+
+module.exports = {
+  createHashHex () {
+    const hash = crypto.createHash('sha256')
+    const args = [...arguments]
+    args.forEach((arg) => {
+      hash.update(arg + '\0')
+    })
+    return hash.digest().toString('hex')
+  }
+}

--- a/test/local/record_tests.js
+++ b/test/local/record_tests.js
@@ -1,0 +1,79 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+const test = require('tap').test
+const Promise = require('bluebird')
+const Record = require('../../lib/record')
+
+function now() {
+  return 240 * 1000
+}
+
+const ACTION_NAME = 'verifyTotpCode'
+const INVALID_ACTION = 'imNotValidAction'
+
+const config = {
+  actions: [ACTION_NAME],
+  limits: {
+    max: 2,
+    periodMs: 1000,
+    rateLimitIntervalMs: 1000
+  }
+}
+
+test('constructor', (t) => {
+  const record = new Record({}, config)
+  t.equal(record.actions, config.actions, 'actions set')
+  t.equal(record.limits, config.limits, 'limits set')
+  t.end()
+})
+
+test('rate limit works', (t) => {
+  const record = new Record({}, config, now)
+
+  t.equal(record.isRateLimited(), false, 'record is not rate limited')
+  record.rateLimit()
+  t.equal(record.isRateLimited(), true, 'record is rate limited')
+  record.rl = now() - 60 * 1000
+  t.equal(record.isRateLimited(), false, 'record is not rate limited')
+  t.end()
+})
+
+test('updates rate limit with valid action', (t) => {
+  const record = new Record({}, config)
+
+  t.equal(record.isRateLimited(), false, 'record is not rate limited')
+  record.update(ACTION_NAME)
+  t.equal(record.isRateLimited(), false, 'record is not rate limited')
+  record.update(ACTION_NAME)
+  t.equal(record.isRateLimited(), false, 'record is not rate limited')
+
+  const retryAfter = record.update(ACTION_NAME)
+  t.equal(record.isRateLimited(), true, 'record is rate limited')
+  t.equal(retryAfter, 1, 'retry after is set')
+
+  return Promise.delay(1000)
+    .then(() => {
+      t.equal(record.isRateLimited(), false, 'record is not rate limited')
+      t.end()
+    })
+})
+
+test('ignores rate limit with invalid action', (t) => {
+  const record = new Record({}, config)
+
+  t.equal(record.isRateLimited(), false, 'record is not rate limited')
+  record.update(INVALID_ACTION)
+  t.equal(record.isRateLimited(), false, 'record is not rate limited')
+  record.update(INVALID_ACTION)
+  t.equal(record.isRateLimited(), false, 'record is not rate limited')
+  record.update(INVALID_ACTION)
+  t.equal(record.isRateLimited(), false, 'record is not rate limited')
+  t.end()
+})
+
+test('getMinLifetimeMS works', (t) => {
+  const record = new Record({}, config)
+  t.equal(record.getMinLifetimeMS(), config.limits.rateLimitIntervalMs, 'gets the min sms lifetime')
+  t.end()
+})

--- a/test/remote/too_many_totp_codes.js
+++ b/test/remote/too_many_totp_codes.js
@@ -1,0 +1,137 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+const test = require('tap').test
+const TestServer = require('../test_server')
+const Promise = require('bluebird')
+const restify = Promise.promisifyAll(require('restify'))
+const mcHelper = require('../memcache-helper')
+
+function randomEmail() {
+  return Math.floor(Math.random() * 10000) + '@email.com'
+}
+
+function randomIp() {
+  function getSubnet() {
+    return Math.floor(Math.random() * 255)
+  }
+  return [getSubnet(), getSubnet(), getSubnet(), getSubnet()].join('.')
+}
+
+const config = {
+  listen: {
+    port: 7000
+  }
+}
+
+process.env.TOTP_CODE_RULE_MAX = 2
+process.env.TOTP_CODE_RULE_PERIOD_MS = 1000
+process.env.TOTP_CODE_RULE_LIMIT_INTERVAL_MS = 1000
+
+const action = 'verifyTotpCode'
+
+const testServer = new TestServer(config)
+
+const client = restify.createJsonClient({
+  url: 'http://127.0.0.1:' + config.listen.port
+})
+
+Promise.promisifyAll(client, {multiArgs: true})
+
+test('startup', (t) => {
+  testServer.start((err) => {
+    t.type(testServer.server, 'object', 'test server was started')
+    t.notOk(err, 'no errors were returned')
+    t.end()
+  })
+})
+
+test('clear everything', (t) => {
+  mcHelper.clearEverything((err) => {
+    t.notOk(err, 'no errors were returned')
+    t.end()
+  })
+})
+
+test('/check `' + action + '` by email', (t) => {
+  const email = randomEmail()
+  const ip = randomIp()
+  // Send requests until throttled
+  return client.postAsync('/check', {ip, action, email})
+    .spread((req, res, obj) => {
+      t.equal(res.statusCode, 200, 'returns a 200')
+      t.equal(obj.block, false, 'not rate limited')
+      return client.postAsync('/check', {ip, action, email})
+    })
+    .spread((req, res, obj) => {
+      t.equal(res.statusCode, 200, 'returns a 200')
+      t.equal(obj.block, false, 'not rate limited')
+      return client.postAsync('/check', {ip, action, email})
+    })
+    .spread((req, res, obj) => {
+      t.equal(res.statusCode, 200, 'returns a 200')
+      t.equal(obj.block, true, 'rate limited')
+      t.equal(obj.retryAfter, 1, 'rate limit retry amount')
+
+      // Delay ~1s for rate limit to go away
+      return Promise.delay(1010)
+    })
+
+    // Reissue requests to verify that throttling is disabled
+    .then(() => {
+      return client.postAsync('/check', {ip, action, email})
+    })
+    .spread((req, res, obj) => {
+      t.equal(res.statusCode, 200, 'returns a 200')
+      t.equal(obj.block, false, 'not rate limited')
+      t.end()
+    })
+    .catch((err) => {
+      t.fail(err)
+      t.end()
+    })
+})
+
+test('/check `' + action + '` does not rate limit other actions', (t) => {
+  const email = randomEmail()
+  const ip = randomIp()
+  return client.postAsync('/check', {ip, action, email})
+    .spread(() => {
+      return client.postAsync('/check', {ip, action, email})
+    })
+    .spread(() => {
+      return client.postAsync('/check', {ip, action, email})
+    })
+    .spread((req, res, obj) => {
+      t.equal(obj.block, true, 'rate limited')
+      return client.postAsync('/check', {ip, action: 'accountLogin', email})
+    })
+    .spread((req, res, obj) => {
+      t.equal(obj.block, false, 'not rate limited')
+      return client.postAsync('/check', {ip, action: 'accountLogin', email: randomEmail()})
+    })
+    .spread((req, res, obj) => {
+      t.equal(obj.block, false, 'not rate limited')
+      return client.postAsync('/check', {ip: randomIp(), action: 'accountLogin', email})
+    })
+    .spread((req, res, obj) => {
+      t.equal(obj.block, false, 'not rate limited')
+    })
+    .catch((err) => {
+      t.fail(err)
+      t.end()
+    })
+})
+
+test('clear everything', (t) => {
+  mcHelper.clearEverything((err) => {
+    t.notOk(err, 'no errors were returned')
+    t.end()
+  })
+})
+
+test('teardown', (t) => {
+  testServer.stop()
+  t.equal(testServer.server.killed, true, 'test server has been killed')
+  t.end()
+})


### PR DESCRIPTION
Fixes #226 

This PR adds rate limiting to actions that involve checking a TOTP code (only `verifyTotpCode` atm ). Unfortunately, while adding this rate limit, I could not re-use the existing rate limiting structure for ip and email based actions since those limits are defined `config.limits.rateLimitIntervalSeconds`. The TOTP rate limit requirement is 2 checks every 30 seconds (rate the codes are generated).

To support this feature, I decided to build off https://github.com/mozilla/fxa-customs-server/pull/174, which had a lofty goal of refactoring all the things. This PR is a smaller subset that adds support for creating a custom rule for actions and checking limits.

* To maintain backwards comp, a new route is used `/checkWithRule`
* Added a generic record class that stores custom limits and actions for rule
* Records are stored in memcache with key `ip + email + ruleName`

While this doesn't negate the fact we should refactor this service, it does provide the minimum parts needed to support rate limiting TOTP.

@rfk What are your thoughts on this approach?