### PR TITLE
fix(tests): fix dependent tests

### DIFF
--- a/test/memcache-helper.js
+++ b/test/memcache-helper.js
@@ -132,6 +132,9 @@ function clearEverything(cb) {
       return mc.cachedumpAsync(firstServer.server, stats, firstServer[stats].number)
     }).map(function (dumpPromise) {
       return dumpPromise.then(function (dump) {
+        if (! dump) {
+          return
+        }
         // when one key is return as an object pretend it's an array
         if (dump.key && !dump.length) {
           dump = [dump]

--- a/test/remote/block_ip_tests.js
+++ b/test/remote/block_ip_tests.js
@@ -6,9 +6,9 @@ var TestServer = require('../test_server')
 var Promise = require('bluebird')
 var restify = require('restify')
 var mcHelper = require('../memcache-helper')
+const testUtils = require('../utils')
 
 var TEST_EMAIL = 'test@example.com'
-var TEST_IP = '192.0.2.1'
 var ALLOWED_IP = '192.0.3.1'
 const ENDPOINTS = [ '/check', '/checkIpOnly' ]
 
@@ -77,28 +77,30 @@ ENDPOINTS.forEach(endpoint => {
   })
 
   test(`${endpoint} well-formed request`, t => {
-    return client.postAsync(endpoint, { email: TEST_EMAIL, ip: TEST_IP, action: 'accountLogin' })
-      .spread(function (req, res, obj) {
-        t.equal(res.statusCode, 200, 'check worked')
-        t.equal(obj.block, false, 'request was not blocked')
+    const email = testUtils.randomEmail()
+    const ip = testUtils.randomIp()
+    return client.postAsync(endpoint, {email, ip, action: 'accountLogin'})
+        .spread(function (req, res, obj) {
+          t.equal(res.statusCode, 200, 'check worked')
+          t.equal(obj.block, false, 'request was not blocked')
 
-        return client.postAsync('/blockIp', { ip: TEST_IP })
-      })
-      .spread(function (req, res, obj) {
-        t.equal(res.statusCode, 200, 'block request returns a 200')
-        t.ok(obj, 'got an obj, make jshint happy')
+          return client.postAsync('/blockIp', {ip})
+        })
+        .spread(function (req, res, obj) {
+          t.equal(res.statusCode, 200, 'block request returns a 200')
+          t.ok(obj, 'got an obj, make jshint happy')
 
-        return client.postAsync(endpoint, { email: TEST_EMAIL, ip: TEST_IP, action: 'accountLogin' })
-      })
-      .spread(function (req, res, obj) {
-        t.equal(res.statusCode, 200, 'check worked')
-        t.equal(obj.block, true, 'request was blocked')
-        t.end()
-      })
-      .catch(function(err){
-        t.fail(err)
-        t.end()
-      })
+          return client.postAsync(endpoint, {email, ip, action: 'accountLogin'})
+        })
+        .spread(function (req, res, obj) {
+          t.equal(res.statusCode, 200, 'check worked')
+          t.equal(obj.block, true, 'request was blocked')
+          t.end()
+        })
+        .catch(function (err) {
+          t.fail(err)
+          t.end()
+        })
   })
 })
 

--- a/test/remote/send_violations_tests.js
+++ b/test/remote/send_violations_tests.js
@@ -7,13 +7,12 @@ var ReputationServerStub = require('../test_reputation_server')
 var Promise = require('bluebird')
 var restify = require('restify')
 var mcHelper = require('../memcache-helper')
+const testUtils = require('../utils')
 
 var TEST_EMAIL = 'test@example.com'
 var TEST_EMAIL_2 = 'test+2@example.com'
 var TEST_IP = '192.0.2.1'
 var ALLOWED_IP = '192.0.3.1'
-var TEST_UID = 'test-uid'
-var TEST_ACTION = 'action1'
 var TEST_CHECK_ACTION = 'recoveryEmailVerifyCode'
 
 // wait for the violation to be sent for endpoints that respond
@@ -107,26 +106,29 @@ test(
 )
 
 test(
-  '/checkAuthenticated rate limited runs when sends violation fails',
-  function (t) {
-    return client.postAsync('/checkAuthenticated', { action: TEST_ACTION, ip: TEST_IP, uid: TEST_UID })
-      .spread(function (req, res, obj) {
-        t.equal(res.statusCode, 200, 'returns 200 for /checkAuthenticated 1')
-        t.equal(obj.block, false, 'not rate limited')
-        return client.postAsync('/checkAuthenticated', { action: TEST_ACTION, ip: TEST_IP, uid: TEST_UID })
-      }).spread(function (req, res, obj) {
-        t.equal(res.statusCode, 200, 'returns 200 for /checkAuthenticated 2')
-        t.equal(obj.block, false, 'not rate limited')
-        return client.postAsync('/checkAuthenticated', { action: TEST_ACTION, ip: TEST_IP, uid: TEST_UID })
-      }).spread(function (req, res, obj) {
-        t.equal(res.statusCode, 200, 'returns 200 for /checkAuthenticated 3')
-        t.equal(obj.block, true, 'rate limited')
-        t.end()
-      }).catch(function(err) {
-        t.fail(err)
-        t.end()
-      })
-  }
+    '/checkAuthenticated rate limited runs when sends violation fails',
+    function (t) {
+      const ip = testUtils.randomIp()
+      const action = testUtils.randomHexString(5)
+      const uid = testUtils.randomHexString(5)
+      return client.postAsync('/checkAuthenticated', {action, ip, uid})
+          .spread(function (req, res, obj) {
+            t.equal(res.statusCode, 200, 'returns 200 for /checkAuthenticated 1')
+            t.equal(obj.block, false, 'not rate limited')
+            return client.postAsync('/checkAuthenticated', {action, ip, uid})
+          }).spread(function (req, res, obj) {
+            t.equal(res.statusCode, 200, 'returns 200 for /checkAuthenticated 2')
+            t.equal(obj.block, false, 'not rate limited')
+            return client.postAsync('/checkAuthenticated', {action, ip, uid})
+          }).spread(function (req, res, obj) {
+            t.equal(res.statusCode, 200, 'returns 200 for /checkAuthenticated 3')
+            t.equal(obj.block, true, 'rate limited')
+            t.end()
+          }).catch(function (err) {
+            t.fail(err)
+            t.end()
+          })
+    }
 )
 
 test(
@@ -192,24 +194,26 @@ test(
 test(
   'sends violation /check resulting in lockout',
   function (t) {
-    return client.postAsync('/check', { email: TEST_EMAIL, ip: TEST_IP, action: TEST_CHECK_ACTION })
+    const email = testUtils.randomEmail()
+    const ip = testUtils.randomIp()
+    return client.postAsync('/check', { email, ip, action: TEST_CHECK_ACTION })
       .spread(function (req, res, obj) {
         t.equal(res.statusCode, 200, 'first action noted')
         t.equal(obj.block, false, 'first action not blocked')
-        return client.postAsync('/check', { email: TEST_EMAIL, ip: TEST_IP, action: TEST_CHECK_ACTION })
+        return client.postAsync('/check', { email, ip, action: TEST_CHECK_ACTION })
       }).spread(function (req, res, obj) {
         t.equal(res.statusCode, 200, 'second action noted')
         t.equal(obj.block, false, 'second action not blocked')
-        return client.postAsync('/check', { email: TEST_EMAIL, ip: TEST_IP, action: TEST_CHECK_ACTION })
+        return client.postAsync('/check', { email, ip, action: TEST_CHECK_ACTION })
       }).spread(function (req, res, obj) {
         t.equal(res.statusCode, 200, 'third action attempt noted')
         t.equal(obj.block, true, 'third action blocked')
         return Promise.delay(TEST_DELAY_MS)
       }).then(function () {
-        return reputationClient.getAsync('/mostRecentViolation/' + TEST_IP)
+        return reputationClient.getAsync('/mostRecentViolation/' + ip)
       }).spread(function (req, res, obj) {
         t.equal(res.body, '"fxa:request.check.block.' + TEST_CHECK_ACTION + '"', 'sends violation when /check')
-        return reputationClient.delAsync('/mostRecentViolation/' + TEST_IP)
+        return reputationClient.delAsync('/mostRecentViolation/' + ip)
       }).spread(function (req, res, obj) {
         t.equal(res.statusCode, 200, 'Failed to clear sent violation from test server.')
         t.end()
@@ -223,24 +227,27 @@ test(
 test(
   'sends violation when /checkAuthenticated rate limited',
   function (t) {
-    return client.postAsync('/checkAuthenticated', { action: TEST_ACTION, ip: TEST_IP, uid: TEST_UID })
+    const ip = testUtils.randomIp()
+    const action = testUtils.randomHexString(5)
+    const uid = testUtils.randomHexString(5)
+    return client.postAsync('/checkAuthenticated', { action, ip, uid })
       .spread(function (req, res, obj) {
         t.equal(res.statusCode, 200, 'returns 200 for /checkAuthenticated 1')
         t.equal(obj.block, false, 'not rate limited')
-        return client.postAsync('/checkAuthenticated', { action: TEST_ACTION, ip: TEST_IP, uid: TEST_UID })
+        return client.postAsync('/checkAuthenticated', { action, ip, uid })
       }).spread(function (req, res, obj) {
         t.equal(res.statusCode, 200, 'returns 200 for /checkAuthenticated 2')
         t.equal(obj.block, false, 'not rate limited')
-        return client.postAsync('/checkAuthenticated', { action: TEST_ACTION, ip: TEST_IP, uid: TEST_UID })
+        return client.postAsync('/checkAuthenticated', { action, ip, uid })
       }).spread(function (req, res, obj) {
         t.equal(res.statusCode, 200, 'returns 200 for /checkAuthenticated 3')
         t.equal(obj.block, true, 'rate limited')
         return Promise.delay(TEST_DELAY_MS)
       }).then(function () {
-        return reputationClient.getAsync('/mostRecentViolation/' + TEST_IP)
+        return reputationClient.getAsync('/mostRecentViolation/' + ip)
       }).spread(function (req, res, obj) {
-        t.equal(res.body, '"fxa:request.checkAuthenticated.block.action1"', 'Violation sent.')
-        return reputationClient.delAsync('/mostRecentViolation/' + TEST_IP)
+        t.equal(res.body, `"fxa:request.checkAuthenticated.block.${action}"`, 'Violation sent.')
+        return reputationClient.delAsync('/mostRecentViolation/' + ip)
       }).spread(function (req, res, obj) {
         t.equal(res.statusCode, 200, 'Failed to clear sent violation from test server.')
         t.end()

--- a/test/remote/too_many_verify_codes.js
+++ b/test/remote/too_many_verify_codes.js
@@ -6,6 +6,7 @@ const TestServer = require('../test_server')
 const Promise = require('bluebird')
 const restify = Promise.promisifyAll(require('restify'))
 const mcHelper = require('../memcache-helper')
+const testUtils = require('../utils')
 
 const TEST_IP = '192.0.2.1'
 
@@ -53,16 +54,18 @@ VERIFY_CODE_ACTIONS.forEach((action) => {
 
   test('/check `' + action + '` by email', (t) => {
     // Send requests until throttled
-    return client.postAsync('/check', {ip: TEST_IP, email: 'test1@example.com', action: action})
+    const email = testUtils.randomEmail()
+    const ip = testUtils.randomIp()
+    return client.postAsync('/check', {ip, email, action})
       .spread((req, res, obj) => {
         t.equal(res.statusCode, 200, 'returns a 200')
         t.equal(obj.block, false, 'not rate limited')
-        return client.postAsync('/check', {ip: TEST_IP, email: 'test1@example.com', action: action})
+        return client.postAsync('/check', {ip, email, action})
       })
       .spread((req, res, obj) => {
         t.equal(res.statusCode, 200, 'returns a 200')
         t.equal(obj.block, false, 'not rate limited')
-        return client.postAsync('/check', {ip: TEST_IP, email: 'test1@example.com', action: action})
+        return client.postAsync('/check', {ip, email, action})
       })
       .spread((req, res, obj) => {
         t.equal(res.statusCode, 200, 'returns a 200')
@@ -75,7 +78,7 @@ VERIFY_CODE_ACTIONS.forEach((action) => {
 
       // Reissue requests to verify that throttling is disabled
       .then(() => {
-        return client.postAsync('/check', {ip: TEST_IP, email: 'test1@example.com', action: action})
+        return client.postAsync('/check', {ip, email, action})
       })
       .spread((req, res, obj) => {
         t.equal(res.statusCode, 200, 'returns a 200')

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+const crypto = require('crypto')
+
+module.exports = {
+  getSubnet: function () {
+    return Math.floor(Math.random() * 255)
+  },
+
+  randomEmail: function () {
+    return Math.floor(Math.random() * 10000) + '@email.com'
+  },
+
+  randomIp: function () {
+    function getSubnet() {
+      return Math.floor(Math.random() * 255)
+    }
+
+    return [getSubnet(), getSubnet(), getSubnet(), getSubnet()].join('.')
+  },
+
+  randomHexString: function (length) {
+    if (length === 0) {
+      return ''
+    }
+
+    return crypto.randomBytes(length).toString('hex').slice(0, length)
+  }
+}

--- a/test/utils.js
+++ b/test/utils.js
@@ -6,10 +6,6 @@
 const crypto = require('crypto')
 
 module.exports = {
-  getSubnet: function () {
-    return Math.floor(Math.random() * 255)
-  },
-
   randomEmail: function () {
     return Math.floor(Math.random() * 10000) + '@email.com'
   },


### PR DESCRIPTION
I was setting up a new computer yesterday and found that these tests depended on a previous tests state which caused some test failures. I suspect that the older computer was slow enough that the limits were reset before the next test. This fixes the issue my using unique ips, emails and actions when needed.

Unfortunately, there are probably more tests that have shared states but it would be more work to find and fix them than to do a complete refactor such as https://github.com/mozilla/fxa-customs-server/pull/174.