### PR TITLE
fix(sms): Reduce sms rate-limit interval to half an hour.

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -110,7 +110,7 @@ module.exports = function (fs, path, url, convict) {
       smsRateLimit: {
         limitIntervalSeconds: {
           doc: 'Duration of automatic throttling for sms',
-          default: 60 * 60,
+          default: 30 * 60,
           format: 'nat',
           env: 'SMS_RATE_LIMIT_INTERVAL_SECONDS'
         },


### PR DESCRIPTION
As discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1448854#c5; @philbooth r?