### PR TITLE
chore(deps): Update ip-reputation-js-client dependency.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -80,13 +80,14 @@
       }
     },
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true,
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
         "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
@@ -168,14 +169,14 @@
       "dev": true
     },
     "asn1": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-      "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "assert-plus": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-      "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
       "version": "2.6.0",
@@ -188,20 +189,17 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-      "dev": true
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
-      "dev": true
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
     "backoff": {
       "version": "2.5.0",
@@ -220,7 +218,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
@@ -240,12 +237,18 @@
       "integrity": "sha1-94D+Q+GnplEPZ6vX0NeVM6QN3eY="
     },
     "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "4.2.1"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+        }
       }
     },
     "brace-expansion": {
@@ -318,10 +321,9 @@
       }
     },
     "caseless": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-      "dev": true
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "1.1.3",
@@ -366,8 +368,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -397,7 +398,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -605,6 +605,36 @@
           "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
           "dev": true
         },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
         "esprima": {
           "version": "2.7.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
@@ -621,6 +651,36 @@
             "combined-stream": "1.0.6",
             "mime-types": "2.1.18"
           }
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.15.1",
+            "is-my-json-valid": "2.17.2",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -680,17 +740,23 @@
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.4",
             "tunnel-agent": "0.4.3",
-            "uuid": "3.0.0"
+            "uuid": "3.2.1"
           }
         },
-        "tough-cookie": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
-            "punycode": "1.4.1"
+            "hoek": "2.16.3"
           }
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+          "dev": true
         }
       }
     },
@@ -705,12 +771,26 @@
       }
     },
     "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "2.10.1"
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        },
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+        }
       }
     },
     "csv": {
@@ -775,17 +855,8 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "dateformat": {
@@ -857,8 +928,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.1",
@@ -908,7 +978,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
@@ -1176,25 +1245,22 @@
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extsprintf": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
-      "integrity": "sha1-WtlGwi9bMrp/jNdCZxHG6KP8JSk="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-      "dev": true
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1287,14 +1353,12 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-      "dev": true,
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
@@ -1374,17 +1438,8 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "git-raw-commits": {
@@ -1796,19 +1851,15 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-      "dev": true,
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "chalk": "1.1.3",
-        "commander": "2.15.1",
-        "is-my-json-valid": "2.17.2",
-        "pinkie-promise": "2.0.1"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has-ansi": {
@@ -1830,22 +1881,27 @@
       }
     },
     "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+        }
       }
     },
     "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+      "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw=="
     },
     "hooker": {
       "version": "0.2.3",
@@ -1876,13 +1932,13 @@
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
     },
     "http-signature": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-      "integrity": "sha1-F5bPZ6ABrVzWhJ3KCZFIXwkIn+Y=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "asn1": "0.1.11",
-        "assert-plus": "0.1.5",
-        "ctype": "0.5.3"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
       }
     },
     "https-proxy-agent": {
@@ -1965,6897 +2021,19 @@
       "integrity": "sha1-ErFilKOJJUhtYYoRA1BuTrT4spY="
     },
     "ip-reputation-js-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ip-reputation-js-client/-/ip-reputation-js-client-2.2.0.tgz",
-      "integrity": "sha512-O/hfE9q30kRCzmy8qSNlZ3dqRQXqDjgD8bfkvBht2fZif3FXqs1nloLCpWv9acQjdKHqEirLCicqcUU6oH6paA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ip-reputation-js-client/-/ip-reputation-js-client-3.0.1.tgz",
+      "integrity": "sha512-JtcqPSVcvcchWYIl2u6pk1crB039VX4ncZEn6s/BYwJsc8IWQTpvlnVMS5mXh41uKUR7XUUGA+ZUx6uzh9oFzg==",
       "requires": {
-        "bluebird": "3.4.6",
-        "joi": "12.0.0",
+        "bluebird": "3.5.1",
+        "joi": "13.3.0",
         "request": "2.85.0"
       },
       "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-        },
-        "acorn": {
-          "version": "5.5.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
-        },
-        "acorn-jsx": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-          "requires": {
-            "acorn": "3.3.0"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
-            }
-          }
-        },
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
-        },
-        "ajv-keywords": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-          "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
-        },
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "requires": {
-            "sprintf-js": "1.0.3"
-          }
-        },
-        "array-differ": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-          "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
-        },
-        "array-find-index": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-          "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
-        },
-        "array-union": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-          "requires": {
-            "array-uniq": "1.0.3"
-          }
-        },
-        "array-uniq": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-          "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "bind-obj-methods": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-2.0.0.tgz",
-          "integrity": "sha512-3/qRXczDi2Cdbz6jE+W3IflJOutRVica8frpBn14de1mBOkzDo+6tY33kNhvkw54Kn3PzRRD2VnGbGPcTAk4sw=="
-        },
-        "bl": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-          "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
-          "requires": {
-            "readable-stream": "2.0.6"
-          }
-        },
         "bluebird": {
-          "version": "3.4.6",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz",
-          "integrity": "sha1-AdqNgh2HgT0ViWfnQ9X+bGLPjA8="
-        },
-        "boom": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-from": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-          "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-        },
-        "caller-path": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-          "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-          "requires": {
-            "callsites": "0.2.0"
-          }
-        },
-        "callsites": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
-        },
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-        },
-        "camelcase-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-          "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
-          }
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "circular-json": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-          "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
-        },
-        "clean-yaml-object": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
-          "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g="
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "requires": {
-            "restore-cursor": "1.0.1"
-          }
-        },
-        "cli-width": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-          "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
-        },
-        "co": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
-        "coffee-script": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz",
-          "integrity": "sha1-EpOLz5vhlI+gBvkuDEyegXBRCMA="
-        },
-        "color-support": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-          "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
-        },
-        "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
-        },
-        "combined-stream": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
-        "concat-stream": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-          "requires": {
-            "buffer-from": "1.0.0",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.5",
-            "typedarray": "0.0.6"
-          },
-          "dependencies": {
-            "process-nextick-args": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-            },
-            "readable-stream": {
-              "version": "2.3.5",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "coveralls": {
-          "version": "2.11.14",
-          "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.11.14.tgz",
-          "integrity": "sha1-ZFoFrHKqTy7oEcZnOQ1K028MLiY=",
-          "requires": {
-            "js-yaml": "3.6.1",
-            "lcov-parse": "0.0.10",
-            "log-driver": "1.2.5",
-            "minimist": "1.2.0",
-            "request": "2.75.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-              "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-            },
-            "boom": {
-              "version": "2.10.1",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "caseless": {
-              "version": "0.11.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-              "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-              "requires": {
-                "boom": "2.10.1"
-              }
-            },
-            "form-data": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
-              "integrity": "sha1-bwrrrcxdoWwT4ezBETfYX5uIOyU=",
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
-              }
-            },
-            "har-validator": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-              "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-              "requires": {
-                "chalk": "1.1.3",
-                "commander": "2.15.1",
-                "is-my-json-valid": "2.17.2",
-                "pinkie-promise": "2.0.1"
-              }
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-              "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
-              }
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-              "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.1"
-              }
-            },
-            "node-uuid": {
-              "version": "1.4.8",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-              "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-            },
-            "qs": {
-              "version": "6.2.3",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
-              "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4="
-            },
-            "request": {
-              "version": "2.75.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
-              "integrity": "sha1-0rgmiihtoT6qXQGt9dGMyQ9lfZM=",
-              "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "bl": "1.1.2",
-                "caseless": "0.11.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.0.0",
-                "har-validator": "2.0.6",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "node-uuid": "1.4.8",
-                "oauth-sign": "0.8.2",
-                "qs": "6.2.3",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.4.3"
-              }
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-              "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.4.3",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-              "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
-            }
-          }
-        },
-        "cross-spawn": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-          "requires": {
-            "lru-cache": "4.1.2",
-            "which": "1.2.14"
-          }
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-              "requires": {
-                "hoek": "4.2.1"
-              }
-            }
-          }
-        },
-        "currently-unhandled": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-          "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-          "requires": {
-            "array-find-index": "1.0.2"
-          }
-        },
-        "d": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-          "requires": {
-            "es5-ext": "0.10.41"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "dateformat": {
-          "version": "1.0.12",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-          "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-          "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-        },
-        "deep-is": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
-        },
-        "del": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-          "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-          "requires": {
-            "globby": "5.0.0",
-            "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.0",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "rimraf": "2.2.8"
-          }
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-        },
-        "diff": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-          "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
-        },
-        "doctrine": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
-          }
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "error-ex": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-          "requires": {
-            "is-arrayish": "0.2.1"
-          }
-        },
-        "es5-ext": {
-          "version": "0.10.41",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.41.tgz",
-          "integrity": "sha512-MYK02wXfwTMie5TEJWPolgOsXEmz7wKCQaGzgmRjZOoV6VLG8I5dSv2bn6AOClXhK64gnSQTQ9W9MKvx87J4gw==",
-          "requires": {
-            "es6-iterator": "2.0.3",
-            "es6-symbol": "3.1.1",
-            "next-tick": "1.0.0"
-          }
-        },
-        "es6-iterator": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-          "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.41",
-            "es6-symbol": "3.1.1"
-          }
-        },
-        "es6-map": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-          "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.41",
-            "es6-iterator": "2.0.3",
-            "es6-set": "0.1.5",
-            "es6-symbol": "3.1.1",
-            "event-emitter": "0.3.5"
-          }
-        },
-        "es6-set": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-          "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.41",
-            "es6-iterator": "2.0.3",
-            "es6-symbol": "3.1.1",
-            "event-emitter": "0.3.5"
-          }
-        },
-        "es6-symbol": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.41"
-          }
-        },
-        "es6-weak-map": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-          "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.41",
-            "es6-iterator": "2.0.3",
-            "es6-symbol": "3.1.1"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-        },
-        "escope": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-          "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-          "requires": {
-            "es6-map": "0.1.5",
-            "es6-weak-map": "2.0.2",
-            "esrecurse": "4.2.1",
-            "estraverse": "4.2.0"
-          }
-        },
-        "eslint": {
-          "version": "2.13.1",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
-          "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
-          "requires": {
-            "chalk": "1.1.3",
-            "concat-stream": "1.6.2",
-            "debug": "2.6.9",
-            "doctrine": "1.5.0",
-            "es6-map": "0.1.5",
-            "escope": "3.6.0",
-            "espree": "3.5.4",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "file-entry-cache": "1.3.1",
-            "glob": "7.0.6",
-            "globals": "9.18.0",
-            "ignore": "3.3.7",
-            "imurmurhash": "0.1.4",
-            "inquirer": "0.12.0",
-            "is-my-json-valid": "2.17.2",
-            "is-resolvable": "1.1.0",
-            "js-yaml": "3.6.1",
-            "json-stable-stringify": "1.0.1",
-            "levn": "0.3.0",
-            "lodash": "4.17.5",
-            "mkdirp": "0.5.1",
-            "optionator": "0.8.2",
-            "path-is-absolute": "1.0.1",
-            "path-is-inside": "1.0.2",
-            "pluralize": "1.2.1",
-            "progress": "1.1.8",
-            "require-uncached": "1.0.3",
-            "shelljs": "0.6.1",
-            "strip-json-comments": "1.0.4",
-            "table": "3.8.3",
-            "text-table": "0.2.0",
-            "user-home": "2.0.0"
-          }
-        },
-        "eslint-config-fxa": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-config-fxa/-/eslint-config-fxa-2.1.0.tgz",
-          "integrity": "sha1-/t2SfMRlXQau8jorJWTkRDLWgHY="
-        },
-        "espree": {
-          "version": "3.5.4",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-          "requires": {
-            "acorn": "5.5.3",
-            "acorn-jsx": "3.0.1"
-          }
-        },
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
-        },
-        "esrecurse": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-          "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-          "requires": {
-            "estraverse": "4.2.0"
-          }
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
-        },
-        "event-emitter": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-          "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-          "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.41"
-          }
-        },
-        "eventemitter2": {
-          "version": "0.4.14",
-          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-          "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
-        },
-        "events-to-array": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
-          "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y="
-        },
-        "exit": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-          "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
-        },
-        "exit-hook": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-          "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
-        },
-        "extend": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-          "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
-          }
-        },
-        "file-entry-cache": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
-          "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
-          "requires": {
-            "flat-cache": "1.3.0",
-            "object-assign": "4.1.1"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "findup-sync": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-          "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
-          "requires": {
-            "glob": "5.0.15"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "5.0.15",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-              "requires": {
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            }
-          }
-        },
-        "flat-cache": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-          "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-          "requires": {
-            "circular-json": "0.3.3",
-            "del": "2.2.2",
-            "graceful-fs": "4.1.11",
-            "write": "0.2.1"
-          }
-        },
-        "foreachasync": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
-          "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY="
-        },
-        "foreground-child": {
-          "version": "1.5.6",
-          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
-          "requires": {
-            "cross-spawn": "4.0.2",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-        },
-        "form-data": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
-          }
-        },
-        "fs-exists-cached": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
-          "integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84="
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-        },
-        "function-loop": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/function-loop/-/function-loop-1.0.1.tgz",
-          "integrity": "sha1-gHa7MF6OajzO7ikgdl8zDRkPNAw="
-        },
-        "generate-function": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
-        },
-        "generate-object-property": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-          "requires": {
-            "is-property": "1.0.2"
-          }
-        },
-        "get-stdin": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
-        },
-        "getobject": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
-          "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw="
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        },
-        "globby": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-          "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.0.6",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-        },
-        "grunt": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.1.tgz",
-          "integrity": "sha1-6HeHZOlEsY8yuw8QuQeEdcnftWs=",
-          "requires": {
-            "coffee-script": "1.10.0",
-            "dateformat": "1.0.12",
-            "eventemitter2": "0.4.14",
-            "exit": "0.1.2",
-            "findup-sync": "0.3.0",
-            "glob": "7.0.6",
-            "grunt-cli": "1.2.0",
-            "grunt-known-options": "1.1.0",
-            "grunt-legacy-log": "1.0.1",
-            "grunt-legacy-util": "1.0.0",
-            "iconv-lite": "0.4.19",
-            "js-yaml": "3.5.5",
-            "minimatch": "3.0.4",
-            "nopt": "3.0.6",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.2.8"
-          },
-          "dependencies": {
-            "js-yaml": {
-              "version": "3.5.5",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
-              "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
-              "requires": {
-                "argparse": "1.0.10",
-                "esprima": "2.7.3"
-              }
-            }
-          }
-        },
-        "grunt-bump": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.8.0.tgz",
-          "integrity": "sha1-0//gzzzws44JYHt4U49CpTHq/lU=",
-          "requires": {
-            "semver": "5.5.0"
-          }
-        },
-        "grunt-cli": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
-          "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
-          "requires": {
-            "findup-sync": "0.3.0",
-            "grunt-known-options": "1.1.0",
-            "nopt": "3.0.6",
-            "resolve": "1.1.7"
-          }
-        },
-        "grunt-copyright": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.3.0.tgz",
-          "integrity": "sha1-5uv5UV8sRILqMV1YZYKHjSMUY5g="
-        },
-        "grunt-eslint": {
-          "version": "18.0.0",
-          "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-18.0.0.tgz",
-          "integrity": "sha1-QOAe2Vx++J4PBdygHy3bM8JtEjg=",
-          "requires": {
-            "chalk": "1.1.3",
-            "eslint": "2.13.1"
-          }
-        },
-        "grunt-known-options": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
-          "integrity": "sha1-pCdO6zL6dl2lp6OxcSYXzjsUQUk="
-        },
-        "grunt-legacy-log": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.1.tgz",
-          "integrity": "sha512-rwuyqNKlI0IPz0DvxzJjcEiQEBaBNVeb1LFoZKxSmHLETFUwhwUrqOsPIxURTKSwNZHZ4ht1YLBYmVU0YZAzHQ==",
-          "requires": {
-            "colors": "1.1.2",
-            "grunt-legacy-log-utils": "1.0.0",
-            "hooker": "0.2.3",
-            "lodash": "4.17.5",
-            "underscore.string": "3.3.4"
-          }
-        },
-        "grunt-legacy-log-utils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
-          "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
-          "requires": {
-            "chalk": "1.1.3",
-            "lodash": "4.3.0"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
-              "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ="
-            }
-          }
-        },
-        "grunt-legacy-util": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
-          "integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
-          "requires": {
-            "async": "1.5.2",
-            "exit": "0.1.2",
-            "getobject": "0.1.0",
-            "hooker": "0.2.3",
-            "lodash": "4.3.0",
-            "underscore.string": "3.2.3",
-            "which": "1.2.14"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
-              "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ="
-            },
-            "underscore.string": {
-              "version": "3.2.3",
-              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
-              "integrity": "sha1-gGmSYzZl1eX8tNsfs6hi62jp5to="
-            }
-          }
-        },
-        "grunt-nsp": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/grunt-nsp/-/grunt-nsp-2.3.1.tgz",
-          "integrity": "sha1-bB0l+35yU36GfX1NNQb6oJTpejg=",
-          "requires": {
-            "nsp": "2.8.1"
-          }
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-          "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.1",
-            "sntp": "2.1.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        },
-        "hooker": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-          "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk="
-        },
-        "hosted-git-info": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-          "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-        },
-        "ignore": {
-          "version": "3.3.7",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-          "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-        },
-        "indent-string": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-          "requires": {
-            "repeating": "2.0.1"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "inquirer": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-          "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-          "requires": {
-            "ansi-escapes": "1.4.0",
-            "ansi-regex": "2.1.1",
-            "chalk": "1.1.3",
-            "cli-cursor": "1.0.2",
-            "cli-width": "2.2.0",
-            "figures": "1.7.0",
-            "lodash": "4.17.5",
-            "readline2": "1.0.1",
-            "run-async": "0.1.0",
-            "rx-lite": "3.1.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
-          }
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-          "requires": {
-            "builtin-modules": "1.1.1"
-          }
-        },
-        "is-finite": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-my-ip-valid": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-          "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
-        },
-        "is-my-json-valid": {
-          "version": "2.17.2",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-          "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
-          "requires": {
-            "generate-function": "2.0.0",
-            "generate-object-property": "1.2.0",
-            "is-my-ip-valid": "1.0.0",
-            "jsonpointer": "4.0.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "is-path-cwd": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-          "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
-        },
-        "is-path-in-cwd": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-          "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-          "requires": {
-            "is-path-inside": "1.0.1"
-          }
-        },
-        "is-path-inside": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-          "requires": {
-            "path-is-inside": "1.0.2"
-          }
-        },
-        "is-property": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
-        },
-        "is-resolvable": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-          "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-        },
-        "is-utf8": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "isemail": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.1.tgz",
-          "integrity": "sha512-mVjAjvdPkpwXW61agT2E9AkGoegZO7SdJGCezWwxnETL58f5KwJ4vSVAMBUL5idL6rTlYAIGkX3n4suiviMLNw==",
-          "requires": {
-            "punycode": "2.1.0"
-          }
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-        },
-        "joi": {
-          "version": "12.0.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-12.0.0.tgz",
-          "integrity": "sha512-z0FNlV4NGgjQN1fdtHYXf5kmgludM65fG/JlXzU6+rwkt9U5UWuXVYnXa2FpK0u6+qBuCmrm5byPNuiiddAHvQ==",
-          "requires": {
-            "hoek": "4.2.1",
-            "isemail": "3.1.1",
-            "topo": "2.0.2"
-          }
-        },
-        "js-yaml": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-          "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-          "requires": {
-            "argparse": "1.0.10",
-            "esprima": "2.7.3"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-        },
-        "jsonpointer": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-          "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "lcov-parse": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-          "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
-        },
-        "levn": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-          "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
-          }
-        },
-        "load-grunt-tasks": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.5.0.tgz",
-          "integrity": "sha1-VuMQdRtYYXgmpiqa/M7Q5KAMhDA=",
-          "requires": {
-            "arrify": "1.0.1",
-            "multimatch": "2.1.0",
-            "pkg-up": "1.0.0",
-            "resolve-pkg": "0.1.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-        },
-        "log-driver": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
-          "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY="
-        },
-        "loud-rejection": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-          "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-          "requires": {
-            "currently-unhandled": "0.4.1",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-          "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
-        },
-        "meow": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-          "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
-          }
-        },
-        "mime-db": {
-          "version": "1.33.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
-        },
-        "mime-types": {
-          "version": "2.1.18",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-          "requires": {
-            "mime-db": "1.33.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "1.1.11"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "minipass": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-          "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
-          },
-          "dependencies": {
-            "yallist": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-              "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-            }
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "multimatch": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-          "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-          "requires": {
-            "array-differ": "1.0.0",
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "minimatch": "3.0.4"
-          }
-        },
-        "mute-stream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-          "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
-        },
-        "next-tick": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-          "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "requires": {
-            "abbrev": "1.1.1"
-          }
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-          "requires": {
-            "hosted-git-info": "2.6.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.3"
-          }
-        },
-        "nsp": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/nsp/-/nsp-2.8.1.tgz",
-          "integrity": "sha512-jvjDg2Gsw4coD/iZ5eQddsDlkvnwMCNnpG05BproSnuG+Gr1bSQMwWMcQeYje+qdDl3XznmhblMPLpZLecTORQ==",
-          "requires": {
-            "chalk": "1.1.3",
-            "cli-table": "0.3.1",
-            "cvss": "1.0.2",
-            "https-proxy-agent": "1.0.0",
-            "joi": "6.10.1",
-            "nodesecurity-npm-utils": "5.0.0",
-            "path-is-absolute": "1.0.1",
-            "rc": "1.2.1",
-            "semver": "5.4.1",
-            "subcommand": "2.1.0",
-            "wreck": "6.3.0"
-          },
-          "dependencies": {
-            "agent-base": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-              "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
-              "requires": {
-                "extend": "3.0.1",
-                "semver": "5.0.3"
-              },
-              "dependencies": {
-                "semver": {
-                  "version": "5.0.3",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-                  "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
-                }
-              }
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-            },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "boom": {
-              "version": "2.10.1",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              }
-            },
-            "cli-table": {
-              "version": "0.3.1",
-              "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-              "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-              "requires": {
-                "colors": "1.0.3"
-              }
-            },
-            "cliclopts": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz",
-              "integrity": "sha1-aUMcfLWvcjd0sNORG0w3USQxkQ8="
-            },
-            "colors": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-              "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-            },
-            "cvss": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/cvss/-/cvss-1.0.2.tgz",
-              "integrity": "sha1-32fpK/EqeW9J6Sh5nI2zunS5/NY="
-            },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "deep-extend": {
-              "version": "0.4.2",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            },
-            "extend": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-            },
-            "https-proxy-agent": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-              "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-              "requires": {
-                "agent-base": "2.1.1",
-                "debug": "2.6.9",
-                "extend": "3.0.1"
-              }
-            },
-            "ini": {
-              "version": "1.3.4",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
-            },
-            "isemail": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-              "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
-            },
-            "joi": {
-              "version": "6.10.1",
-              "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-              "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-              "requires": {
-                "hoek": "2.16.3",
-                "isemail": "1.2.0",
-                "moment": "2.18.1",
-                "topo": "1.1.0"
-              }
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-            },
-            "moment": {
-              "version": "2.18.1",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-              "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            },
-            "nodesecurity-npm-utils": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-5.0.0.tgz",
-              "integrity": "sha1-Baow3jDKjIRcQEjpT9eOXgi1Xtk="
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-            },
-            "rc": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-              "requires": {
-                "deep-extend": "0.4.2",
-                "ini": "1.3.4",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
-              }
-            },
-            "semver": {
-              "version": "5.4.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-              "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-            },
-            "subcommand": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.1.0.tgz",
-              "integrity": "sha1-XkzspaN3njNlsVEeBfhmh3MC92A=",
-              "requires": {
-                "cliclopts": "1.1.1",
-                "debug": "2.6.9",
-                "minimist": "1.2.0",
-                "xtend": "4.0.1"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-            },
-            "topo": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-              "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "wreck": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz",
-              "integrity": "sha1-oTaXafB7u2LWo3gzanhx/Hc8dAs=",
-              "requires": {
-                "boom": "2.10.1",
-                "hoek": "2.16.3"
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-            }
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-        },
-        "nyc": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/nyc/-/nyc-8.3.2.tgz",
-          "integrity": "sha1-o7elkP4cbEstDj8kr+KLYr+v10U=",
-          "requires": {
-            "archy": "1.0.0",
-            "arrify": "1.0.1",
-            "caching-transform": "1.0.1",
-            "convert-source-map": "1.3.0",
-            "default-require-extensions": "1.0.0",
-            "find-cache-dir": "0.1.1",
-            "find-up": "1.1.2",
-            "foreground-child": "1.5.3",
-            "glob": "7.1.1",
-            "istanbul-lib-coverage": "1.0.0",
-            "istanbul-lib-hook": "1.0.0-alpha.4",
-            "istanbul-lib-instrument": "1.1.4",
-            "istanbul-lib-report": "1.0.0-alpha.3",
-            "istanbul-lib-source-maps": "1.0.2",
-            "istanbul-reports": "1.0.0",
-            "md5-hex": "1.3.0",
-            "micromatch": "2.3.11",
-            "mkdirp": "0.5.1",
-            "resolve-from": "2.0.0",
-            "rimraf": "2.5.4",
-            "signal-exit": "3.0.1",
-            "spawn-wrap": "1.2.4",
-            "test-exclude": "2.1.3",
-            "yargs": "6.2.0",
-            "yargs-parser": "4.0.2"
-          },
-          "dependencies": {
-            "align-text": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-              "requires": {
-                "kind-of": "3.0.4",
-                "longest": "1.0.1",
-                "repeat-string": "1.5.4"
-              }
-            },
-            "amdefine": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-              "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM="
-            },
-            "ansi-regex": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
-            },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "append-transform": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.3.0.tgz",
-              "integrity": "sha1-1pM85KhfCURdnMxMwRkFG3OBqBM="
-            },
-            "archy": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
-            },
-            "arr-diff": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-              "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-              "requires": {
-                "arr-flatten": "1.0.1"
-              }
-            },
-            "arr-flatten": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-              "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs="
-            },
-            "array-unique": {
-              "version": "0.2.1",
-              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-              "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-            },
-            "arrify": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-              "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-            },
-            "async": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-            },
-            "babel-code-frame": {
-              "version": "6.16.0",
-              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-              "integrity": "sha1-+Q5g2ghikJ084JhzO105h8l8uN4=",
-              "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "2.0.0"
-              }
-            },
-            "babel-generator": {
-              "version": "6.17.0",
-              "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-              "integrity": "sha1-uJTjgIvu94APJVBjW/4CS2ImzzM=",
-              "requires": {
-                "babel-messages": "6.8.0",
-                "babel-runtime": "6.11.6",
-                "babel-types": "6.16.0",
-                "detect-indent": "3.0.1",
-                "jsesc": "1.3.0",
-                "lodash": "4.16.4",
-                "source-map": "0.5.6"
-              }
-            },
-            "babel-messages": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-              "integrity": "sha1-v1BHNsqWfm1l7wrbWipflHyODrk=",
-              "requires": {
-                "babel-runtime": "6.11.6"
-              }
-            },
-            "babel-runtime": {
-              "version": "6.11.6",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-              "integrity": "sha1-bbcH/vLUnEm/o8tk79tDa1GLgiI=",
-              "requires": {
-                "core-js": "2.4.1",
-                "regenerator-runtime": "0.9.5"
-              }
-            },
-            "babel-template": {
-              "version": "6.16.0",
-              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-              "integrity": "sha1-4UndGp8Do1+BfdvE0EgZiOfryMo=",
-              "requires": {
-                "babel-runtime": "6.11.6",
-                "babel-traverse": "6.16.0",
-                "babel-types": "6.16.0",
-                "babylon": "6.12.0",
-                "lodash": "4.16.4"
-              }
-            },
-            "babel-traverse": {
-              "version": "6.16.0",
-              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-              "integrity": "sha1-+6ha4f1NEH3pzgAxScxX9TvvDE8=",
-              "requires": {
-                "babel-code-frame": "6.16.0",
-                "babel-messages": "6.8.0",
-                "babel-runtime": "6.11.6",
-                "babel-types": "6.16.0",
-                "babylon": "6.12.0",
-                "debug": "2.2.0",
-                "globals": "8.18.0",
-                "invariant": "2.2.1",
-                "lodash": "4.16.4"
-              }
-            },
-            "babel-types": {
-              "version": "6.16.0",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-              "integrity": "sha1-ccyh2+Uzd2YiXFwZMHHo68vP/P4=",
-              "requires": {
-                "babel-runtime": "6.11.6",
-                "esutils": "2.0.2",
-                "lodash": "4.16.4",
-                "to-fast-properties": "1.0.2"
-              }
-            },
-            "babylon": {
-              "version": "6.12.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.12.0.tgz",
-              "integrity": "sha1-lT5iAuWAYvf1BB/IA35L1OFxQKk="
-            },
-            "balanced-match": {
-              "version": "0.4.2",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-            },
-            "brace-expansion": {
-              "version": "1.1.6",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-              "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-              "requires": {
-                "balanced-match": "0.4.2",
-                "concat-map": "0.0.1"
-              }
-            },
-            "braces": {
-              "version": "1.8.5",
-              "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-              "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-              "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
-              }
-            },
-            "builtin-modules": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-            },
-            "caching-transform": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-              "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
-              "requires": {
-                "md5-hex": "1.3.0",
-                "mkdirp": "0.5.1",
-                "write-file-atomic": "1.2.0"
-              }
-            },
-            "camelcase": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-              "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-              "optional": true
-            },
-            "center-align": {
-              "version": "0.1.3",
-              "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-              "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-              "optional": true,
-              "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
-              }
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              }
-            },
-            "cliui": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-              "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-              "optional": true,
-              "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
-                "wordwrap": "0.0.2"
-              },
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.2",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                  "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-                  "optional": true
-                }
-              }
-            },
-            "code-point-at": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-              "integrity": "sha1-EQTNNPm1tF0+uojxurwZJOHONfs=",
-              "requires": {
-                "number-is-nan": "1.0.1"
-              }
-            },
-            "commondir": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-              "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-            },
-            "convert-source-map": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-              "integrity": "sha1-6fPpxuJyjvwmdmlqcOs4L3MQamc="
-            },
-            "core-js": {
-              "version": "2.4.1",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-              "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
-            },
-            "cross-spawn": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-              "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-              "requires": {
-                "lru-cache": "4.0.1",
-                "which": "1.2.11"
-              }
-            },
-            "debug": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-              "requires": {
-                "ms": "0.7.1"
-              }
-            },
-            "decamelize": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-            },
-            "default-require-extensions": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-              "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-              "requires": {
-                "strip-bom": "2.0.0"
-              }
-            },
-            "detect-indent": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-              "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-              "requires": {
-                "get-stdin": "4.0.1",
-                "minimist": "1.2.0",
-                "repeating": "1.1.3"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-                }
-              }
-            },
-            "error-ex": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-              "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
-              "requires": {
-                "is-arrayish": "0.2.1"
-              }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
-            },
-            "expand-brackets": {
-              "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-              "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-              "requires": {
-                "is-posix-bracket": "0.1.1"
-              }
-            },
-            "expand-range": {
-              "version": "1.8.2",
-              "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-              "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-              "requires": {
-                "fill-range": "2.2.3"
-              }
-            },
-            "extglob": {
-              "version": "0.3.2",
-              "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-              "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-              "requires": {
-                "is-extglob": "1.0.0"
-              }
-            },
-            "filename-regex": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-              "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U="
-            },
-            "fill-range": {
-              "version": "2.2.3",
-              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-              "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-              "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.5",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.5.4"
-              }
-            },
-            "find-cache-dir": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-              "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-              "requires": {
-                "commondir": "1.0.1",
-                "mkdirp": "0.5.1",
-                "pkg-dir": "1.0.0"
-              }
-            },
-            "find-up": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-              "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
-              }
-            },
-            "for-in": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-              "integrity": "sha1-yfluib+tGKVFr17D7TUqHZ5bTcg="
-            },
-            "for-own": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-              "integrity": "sha1-AUm0GjkIjHUV9R6+HBOG1F+TUHI=",
-              "requires": {
-                "for-in": "0.1.6"
-              }
-            },
-            "foreground-child": {
-              "version": "1.5.3",
-              "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.3.tgz",
-              "integrity": "sha1-lN1qumcTiYZ96OV+mfHC7PsVwBo=",
-              "requires": {
-                "cross-spawn": "4.0.2",
-                "signal-exit": "3.0.1"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-            },
-            "get-caller-file": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-              "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
-            },
-            "get-stdin": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-              "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
-            },
-            "glob": {
-              "version": "7.1.1",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-              "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.3",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            },
-            "glob-base": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-              "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-              "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
-              }
-            },
-            "glob-parent": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-              "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-              "requires": {
-                "is-glob": "2.0.1"
-              }
-            },
-            "globals": {
-              "version": "8.18.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-              "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ="
-            },
-            "graceful-fs": {
-              "version": "4.1.9",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-              "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik="
-            },
-            "handlebars": {
-              "version": "4.0.5",
-              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
-              "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
-              "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.7.3"
-              },
-              "dependencies": {
-                "source-map": {
-                  "version": "0.4.4",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                  "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-                  "requires": {
-                    "amdefine": "1.0.0"
-                  }
-                }
-              }
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-              "requires": {
-                "ansi-regex": "2.0.0"
-              }
-            },
-            "has-flag": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-            },
-            "hosted-git-info": {
-              "version": "2.1.5",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-              "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs="
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-            },
-            "invariant": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-              "integrity": "sha1-sJcBBUdmjH4zcCjr6Bbr42yKjVQ=",
-              "requires": {
-                "loose-envify": "1.2.0"
-              }
-            },
-            "invert-kv": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-              "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-            },
-            "is-arrayish": {
-              "version": "0.2.1",
-              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-              "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-            },
-            "is-buffer": {
-              "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-              "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys="
-            },
-            "is-builtin-module": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-              "requires": {
-                "builtin-modules": "1.1.1"
-              }
-            },
-            "is-dotfile": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-              "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0="
-            },
-            "is-equal-shallow": {
-              "version": "0.1.3",
-              "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-              "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-              "requires": {
-                "is-primitive": "2.0.0"
-              }
-            },
-            "is-extendable": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-              "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
-            },
-            "is-extglob": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-            },
-            "is-finite": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-              "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-              "requires": {
-                "number-is-nan": "1.0.1"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "requires": {
-                "number-is-nan": "1.0.1"
-              }
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-              "requires": {
-                "is-extglob": "1.0.0"
-              }
-            },
-            "is-number": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-              "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-              "requires": {
-                "kind-of": "3.0.4"
-              }
-            },
-            "is-posix-bracket": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-              "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-            },
-            "is-primitive": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-              "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-            },
-            "is-utf8": {
-              "version": "0.2.1",
-              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-              "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "isexe": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-              "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA="
-            },
-            "isobject": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "requires": {
-                "isarray": "1.0.0"
-              }
-            },
-            "istanbul-lib-coverage": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0.tgz",
-              "integrity": "sha1-w/m20ibaEkJAZMzof84PtX/fp6I="
-            },
-            "istanbul-lib-hook": {
-              "version": "1.0.0-alpha.4",
-              "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.0-alpha.4.tgz",
-              "integrity": "sha1-jFu59vvYUm4K5s9jmvKCZpBrk48=",
-              "requires": {
-                "append-transform": "0.3.0"
-              }
-            },
-            "istanbul-lib-instrument": {
-              "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.1.4.tgz",
-              "integrity": "sha1-lb5W5cMhRW/9/dySWtTc/Cjtq5w=",
-              "requires": {
-                "babel-generator": "6.17.0",
-                "babel-template": "6.16.0",
-                "babel-traverse": "6.16.0",
-                "babel-types": "6.16.0",
-                "babylon": "6.12.0",
-                "istanbul-lib-coverage": "1.0.0"
-              }
-            },
-            "istanbul-lib-report": {
-              "version": "1.0.0-alpha.3",
-              "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.0.0-alpha.3.tgz",
-              "integrity": "sha1-MtX27H8zyjpgIgnieLLm/xQ0mK8=",
-              "requires": {
-                "async": "1.5.2",
-                "istanbul-lib-coverage": "1.0.0",
-                "mkdirp": "0.5.1",
-                "path-parse": "1.0.5",
-                "rimraf": "2.5.4",
-                "supports-color": "3.1.2"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "3.1.2",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-                  "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-                  "requires": {
-                    "has-flag": "1.0.0"
-                  }
-                }
-              }
-            },
-            "istanbul-lib-source-maps": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.0.2.tgz",
-              "integrity": "sha1-npGw5a5u0gP2fGmjTm6YsQu2mkk=",
-              "requires": {
-                "istanbul-lib-coverage": "1.0.0",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.5.4",
-                "source-map": "0.5.6"
-              }
-            },
-            "istanbul-reports": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.0.0.tgz",
-              "integrity": "sha1-JLTrKx0p1Q8QOzab1CL25kCqB3c=",
-              "requires": {
-                "handlebars": "4.0.5"
-              }
-            },
-            "js-tokens": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-              "integrity": "sha1-eZA/VWPud4zBFi5tzxoAJ8l/nLU="
-            },
-            "jsesc": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-              "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
-            },
-            "kind-of": {
-              "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-              "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
-              "requires": {
-                "is-buffer": "1.1.4"
-              }
-            },
-            "lazy-cache": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-              "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-              "optional": true
-            },
-            "lcid": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-              "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-              "requires": {
-                "invert-kv": "1.0.0"
-              }
-            },
-            "load-json-file": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-              "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-              "requires": {
-                "graceful-fs": "4.1.9",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
-              }
-            },
-            "lodash": {
-              "version": "4.16.4",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-              "integrity": "sha1-Ac4wa5utExnypVKGdPiCl663ASc="
-            },
-            "longest": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
-            },
-            "loose-envify": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-              "integrity": "sha1-aaZarT3lQs9O4PT+dOjjPHCcyw8=",
-              "requires": {
-                "js-tokens": "1.0.3"
-              },
-              "dependencies": {
-                "js-tokens": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-                  "integrity": "sha1-FOVutoyPGpLEPVn1AU7CncIPKuE="
-                }
-              }
-            },
-            "lru-cache": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-              "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
-              "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.0.0"
-              }
-            },
-            "md5-hex": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-              "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-              "requires": {
-                "md5-o-matic": "0.1.1"
-              }
-            },
-            "md5-o-matic": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-              "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
-            },
-            "micromatch": {
-              "version": "2.3.11",
-              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-              "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-              "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.0",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.0.4",
-                "normalize-path": "2.0.1",
-                "object.omit": "2.0.0",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.3"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-              "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-              "requires": {
-                "brace-expansion": "1.1.6"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-            },
-            "normalize-package-data": {
-              "version": "2.3.5",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-              "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
-              "requires": {
-                "hosted-git-info": "2.1.5",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.3.0",
-                "validate-npm-package-license": "3.0.1"
-              }
-            },
-            "normalize-path": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-              "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o="
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-            },
-            "object-assign": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-              "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
-            },
-            "object.omit": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-              "integrity": "sha1-hoWXMz1U5gZilAu0WGBd1q4S/pQ=",
-              "requires": {
-                "for-own": "0.1.4",
-                "is-extendable": "0.1.1"
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-              "requires": {
-                "wrappy": "1.0.2"
-              }
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-              "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-              "requires": {
-                "minimist": "0.0.8",
-                "wordwrap": "0.0.3"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-            },
-            "os-locale": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-              "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-              "requires": {
-                "lcid": "1.0.0"
-              }
-            },
-            "parse-glob": {
-              "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-              "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-              "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.2",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
-              }
-            },
-            "parse-json": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-              "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-              "requires": {
-                "error-ex": "1.3.0"
-              }
-            },
-            "path-exists": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-              "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-              "requires": {
-                "pinkie-promise": "2.0.1"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-            },
-            "path-parse": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-              "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
-            },
-            "path-type": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-              "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-              "requires": {
-                "graceful-fs": "4.1.9",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
-              }
-            },
-            "pify": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-            },
-            "pinkie": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-              "requires": {
-                "pinkie": "2.0.4"
-              }
-            },
-            "pkg-dir": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-              "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-              "requires": {
-                "find-up": "1.1.2"
-              }
-            },
-            "preserve": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-              "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-            },
-            "pseudomap": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-            },
-            "randomatic": {
-              "version": "1.1.5",
-              "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-              "integrity": "sha1-Xp718tVzxnvSuBJK6QtRVuRXhAs=",
-              "requires": {
-                "is-number": "2.1.0",
-                "kind-of": "3.0.4"
-              }
-            },
-            "read-pkg": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-              "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-              "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.3.5",
-                "path-type": "1.1.0"
-              }
-            },
-            "read-pkg-up": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-              "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
-              }
-            },
-            "regenerator-runtime": {
-              "version": "0.9.5",
-              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-              "integrity": "sha1-QD1tQKS9/5wzDdk5Lcuy2ai7ofw="
-            },
-            "regex-cache": {
-              "version": "0.4.3",
-              "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-              "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-              "requires": {
-                "is-equal-shallow": "0.1.3",
-                "is-primitive": "2.0.0"
-              }
-            },
-            "repeat-element": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-              "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
-            },
-            "repeat-string": {
-              "version": "1.5.4",
-              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-              "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU="
-            },
-            "repeating": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-              "requires": {
-                "is-finite": "1.0.2"
-              }
-            },
-            "require-directory": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-              "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-            },
-            "require-main-filename": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-            },
-            "resolve-from": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-              "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
-            },
-            "right-align": {
-              "version": "0.1.3",
-              "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-              "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-              "optional": true,
-              "requires": {
-                "align-text": "0.1.4"
-              }
-            },
-            "rimraf": {
-              "version": "2.5.4",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-              "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-              "requires": {
-                "glob": "7.1.1"
-              }
-            },
-            "semver": {
-              "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-            },
-            "signal-exit": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-              "integrity": "sha1-WkyISZK2OnrNm623iUw+6c/MrYE="
-            },
-            "slide": {
-              "version": "1.1.6",
-              "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-              "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
-            },
-            "source-map": {
-              "version": "0.5.6",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-              "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
-            },
-            "spawn-wrap": {
-              "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.2.4.tgz",
-              "integrity": "sha1-kg6yEadpwJPuv71bDnpdLmirLkA=",
-              "requires": {
-                "foreground-child": "1.5.3",
-                "mkdirp": "0.5.1",
-                "os-homedir": "1.0.2",
-                "rimraf": "2.5.4",
-                "signal-exit": "2.1.2",
-                "which": "1.2.11"
-              },
-              "dependencies": {
-                "signal-exit": {
-                  "version": "2.1.2",
-                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
-                  "integrity": "sha1-N1h5sfkuvDszRIDQONxUam1VhWQ="
-                }
-              }
-            },
-            "spdx-correct": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-              "requires": {
-                "spdx-license-ids": "1.2.2"
-              }
-            },
-            "spdx-expression-parse": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-              "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
-            },
-            "spdx-license-ids": {
-              "version": "1.2.2",
-              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-              "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "requires": {
-                "code-point-at": "1.0.1",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "requires": {
-                "ansi-regex": "2.0.0"
-              }
-            },
-            "strip-bom": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-              "requires": {
-                "is-utf8": "0.2.1"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-            },
-            "test-exclude": {
-              "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-2.1.3.tgz",
-              "integrity": "sha1-qNiWjh2oMmb5hk8oUsVeIg8GQ0o=",
-              "requires": {
-                "arrify": "1.0.1",
-                "micromatch": "2.3.11",
-                "object-assign": "4.1.0",
-                "read-pkg-up": "1.0.1",
-                "require-main-filename": "1.0.1"
-              }
-            },
-            "to-fast-properties": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-              "integrity": "sha1-8/XAw7pymafvmUJ+RGMyV63kMyA="
-            },
-            "uglify-js": {
-              "version": "2.7.3",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.3.tgz",
-              "integrity": "sha1-ObOnMpuJ9exQfjRMbiJWhpjvSGg=",
-              "optional": true,
-              "requires": {
-                "async": "0.2.10",
-                "source-map": "0.5.6",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
-              },
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-                  "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-                  "optional": true
-                },
-                "yargs": {
-                  "version": "3.10.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                  "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-                  "optional": true,
-                  "requires": {
-                    "camelcase": "1.2.1",
-                    "cliui": "2.1.0",
-                    "decamelize": "1.2.0",
-                    "window-size": "0.1.0"
-                  }
-                }
-              }
-            },
-            "uglify-to-browserify": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-              "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-              "optional": true
-            },
-            "validate-npm-package-license": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-              "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-              "requires": {
-                "spdx-correct": "1.0.2",
-                "spdx-expression-parse": "1.0.4"
-              }
-            },
-            "which": {
-              "version": "1.2.11",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
-              "integrity": "sha1-yLLu6muMFln6fB3U/aq+lTPcXos=",
-              "requires": {
-                "isexe": "1.1.2"
-              }
-            },
-            "which-module": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-              "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-            },
-            "window-size": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-              "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-              "optional": true
-            },
-            "wordwrap": {
-              "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-            },
-            "wrap-ansi": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-              "integrity": "sha1-fTD4+HP5pbvDpk2ryNF34HGuQm8=",
-              "requires": {
-                "string-width": "1.0.2"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-            },
-            "write-file-atomic": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.2.0.tgz",
-              "integrity": "sha1-FMZtTkyzygVlwozzt6bz5NWTj6s=",
-              "requires": {
-                "graceful-fs": "4.1.9",
-                "imurmurhash": "0.1.4",
-                "slide": "1.1.6"
-              }
-            },
-            "y18n": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-            },
-            "yallist": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
-              "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ="
-            },
-            "yargs": {
-              "version": "6.2.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.2.0.tgz",
-              "integrity": "sha1-kAEEiVPe+FSVos4dz6aQt6sGD9E=",
-              "requires": {
-                "camelcase": "3.0.0",
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "1.4.0",
-                "read-pkg-up": "1.0.1",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "1.0.2",
-                "which-module": "1.0.0",
-                "window-size": "0.2.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "4.0.2"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                  "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-                },
-                "cliui": {
-                  "version": "3.2.0",
-                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                  "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-                  "requires": {
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1",
-                    "wrap-ansi": "2.0.0"
-                  }
-                },
-                "window-size": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-                  "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
-                }
-              }
-            },
-            "yargs-parser": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.0.2.tgz",
-              "integrity": "sha1-f3FzqMfModgdx8GGkvwHwsLiseA=",
-              "requires": {
-                "camelcase": "3.0.0"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                  "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-                }
-              }
-            }
-          }
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
-        },
-        "opener": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
-          "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg="
-        },
-        "optionator": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-          "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-          "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.6",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-        },
-        "own-or": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/own-or/-/own-or-1.0.0.tgz",
-          "integrity": "sha1-Tod/vtqaLsgAD7wLyuOWRe6L+Nw="
-        },
-        "own-or-env": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.1.tgz",
-          "integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
-          "requires": {
-            "own-or": "1.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-        },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "pkg-up": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
-          "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
-          "requires": {
-            "find-up": "1.1.2"
-          }
-        },
-        "pluralize": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-          "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU="
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "progress": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-        },
-        "punycode": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
-        },
-        "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "readline2": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-          "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "mute-stream": "0.0.5"
-          }
-        },
-        "redent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-          "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
-          }
-        },
-        "repeating": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-          "requires": {
-            "is-finite": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.85.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-          "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
-          }
-        },
-        "require-uncached": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-          "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-          "requires": {
-            "caller-path": "0.1.0",
-            "resolve-from": "1.0.1"
-          }
-        },
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
-        },
-        "resolve-from": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
-        },
-        "resolve-pkg": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-0.1.0.tgz",
-          "integrity": "sha1-AsyZNBDik2livZcWahsHfalyVTE=",
-          "requires": {
-            "resolve-from": "2.0.0"
-          },
-          "dependencies": {
-            "resolve-from": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-              "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
-            }
-          }
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
-        },
-        "run-async": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-          "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-          "requires": {
-            "once": "1.4.0"
-          }
-        },
-        "rx-lite": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-          "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        },
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-        },
-        "shelljs": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
-          "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg="
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-        },
-        "slice-ansi": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "source-map-support": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
-          "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
-          "requires": {
-            "source-map": "0.6.1"
-          }
-        },
-        "spdx-correct": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
-          "requires": {
-            "spdx-expression-parse": "3.0.0",
-            "spdx-license-ids": "3.0.0"
-          }
-        },
-        "spdx-exceptions": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
-        },
-        "spdx-expression-parse": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-          "requires": {
-            "spdx-exceptions": "2.1.0",
-            "spdx-license-ids": "3.0.0"
-          }
-        },
-        "spdx-license-ids": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-          "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-        },
-        "sshpk": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-          "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "stack-utils": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-          "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
-        "strip-indent": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-          "requires": {
-            "get-stdin": "4.0.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        },
-        "table": {
-          "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-          "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
-          "requires": {
-            "ajv": "4.11.8",
-            "ajv-keywords": "1.5.1",
-            "chalk": "1.1.3",
-            "lodash": "4.17.5",
-            "slice-ansi": "0.0.4",
-            "string-width": "2.1.1"
-          },
-          "dependencies": {
-            "ajv": {
-              "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-              "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-              "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
-              }
-            },
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-            },
-            "string-width": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-              "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
-            }
-          }
-        },
-        "tap": {
-          "version": "11.1.3",
-          "resolved": "https://registry.npmjs.org/tap/-/tap-11.1.3.tgz",
-          "integrity": "sha512-DwiAZiQWzALkGEbhhbdi+DqT2nqmqFAJZRvVSnHBpA8khjf7+6kcO76Bx39JA7kclIfQ9Uro1rO4dgP1AWUovw==",
-          "requires": {
-            "bind-obj-methods": "2.0.0",
-            "bluebird": "3.5.1",
-            "clean-yaml-object": "0.1.0",
-            "color-support": "1.1.3",
-            "coveralls": "3.0.0",
-            "foreground-child": "1.5.6",
-            "fs-exists-cached": "1.0.0",
-            "function-loop": "1.0.1",
-            "glob": "7.0.6",
-            "isexe": "2.0.0",
-            "js-yaml": "3.11.0",
-            "minipass": "2.2.4",
-            "mkdirp": "0.5.1",
-            "nyc": "11.6.0",
-            "opener": "1.4.3",
-            "os-homedir": "1.0.2",
-            "own-or": "1.0.0",
-            "own-or-env": "1.0.1",
-            "rimraf": "2.6.2",
-            "signal-exit": "3.0.2",
-            "source-map-support": "0.5.4",
-            "stack-utils": "1.0.1",
-            "tap-mocha-reporter": "3.0.7",
-            "tap-parser": "7.0.0",
-            "tmatch": "3.1.0",
-            "trivial-deferred": "1.0.1",
-            "tsame": "1.1.2",
-            "write-file-atomic": "2.3.0",
-            "yapool": "1.0.0"
-          },
-          "dependencies": {
-            "bluebird": {
-              "version": "3.5.1",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-              "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-            },
-            "coveralls": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz",
-              "integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
-              "requires": {
-                "js-yaml": "3.11.0",
-                "lcov-parse": "0.0.10",
-                "log-driver": "1.2.5",
-                "minimist": "1.2.0",
-                "request": "2.85.0"
-              }
-            },
-            "esprima": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-              "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
-            },
-            "js-yaml": {
-              "version": "3.11.0",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-              "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
-              "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.0"
-              }
-            },
-            "nyc": {
-              "version": "11.6.0",
-              "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.6.0.tgz",
-              "integrity": "sha512-ZaXCh0wmbk2aSBH2B5hZGGvK2s9aM8DIm2rVY+BG3Fx8tUS+bpJSswUVZqOD1YfCmnYRFSqgYJSr7UeeUcW0jg==",
-              "requires": {
-                "archy": "1.0.0",
-                "arrify": "1.0.1",
-                "caching-transform": "1.0.1",
-                "convert-source-map": "1.5.1",
-                "debug-log": "1.0.1",
-                "default-require-extensions": "1.0.0",
-                "find-cache-dir": "0.1.1",
-                "find-up": "2.1.0",
-                "foreground-child": "1.5.6",
-                "glob": "7.1.2",
-                "istanbul-lib-coverage": "1.2.0",
-                "istanbul-lib-hook": "1.1.0",
-                "istanbul-lib-instrument": "1.10.1",
-                "istanbul-lib-report": "1.1.3",
-                "istanbul-lib-source-maps": "1.2.3",
-                "istanbul-reports": "1.3.0",
-                "md5-hex": "1.3.0",
-                "merge-source-map": "1.1.0",
-                "micromatch": "2.3.11",
-                "mkdirp": "0.5.1",
-                "resolve-from": "2.0.0",
-                "rimraf": "2.6.2",
-                "signal-exit": "3.0.2",
-                "spawn-wrap": "1.4.2",
-                "test-exclude": "4.2.1",
-                "yargs": "11.1.0",
-                "yargs-parser": "8.1.0"
-              },
-              "dependencies": {
-                "align-text": {
-                  "version": "0.1.4",
-                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                  "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-                  "requires": {
-                    "kind-of": "3.2.2",
-                    "longest": "1.0.1",
-                    "repeat-string": "1.6.1"
-                  }
-                },
-                "amdefine": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-                  "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-                },
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                },
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-                },
-                "append-transform": {
-                  "version": "0.4.0",
-                  "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-                  "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-                  "requires": {
-                    "default-require-extensions": "1.0.0"
-                  }
-                },
-                "archy": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-                  "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
-                },
-                "arr-diff": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                  "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                  "requires": {
-                    "arr-flatten": "1.1.0"
-                  }
-                },
-                "arr-flatten": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-                  "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
-                },
-                "arr-union": {
-                  "version": "3.1.0",
-                  "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-                  "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
-                },
-                "array-unique": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                  "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-                },
-                "arrify": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                  "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-                },
-                "assign-symbols": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-                  "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
-                },
-                "async": {
-                  "version": "1.5.2",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-                },
-                "atob": {
-                  "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
-                  "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10="
-                },
-                "babel-code-frame": {
-                  "version": "6.26.0",
-                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-                  "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-                  "requires": {
-                    "chalk": "1.1.3",
-                    "esutils": "2.0.2",
-                    "js-tokens": "3.0.2"
-                  }
-                },
-                "babel-generator": {
-                  "version": "6.26.1",
-                  "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-                  "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-                  "requires": {
-                    "babel-messages": "6.23.0",
-                    "babel-runtime": "6.26.0",
-                    "babel-types": "6.26.0",
-                    "detect-indent": "4.0.0",
-                    "jsesc": "1.3.0",
-                    "lodash": "4.17.5",
-                    "source-map": "0.5.7",
-                    "trim-right": "1.0.1"
-                  }
-                },
-                "babel-messages": {
-                  "version": "6.23.0",
-                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-                  "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-                  "requires": {
-                    "babel-runtime": "6.26.0"
-                  }
-                },
-                "babel-runtime": {
-                  "version": "6.26.0",
-                  "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-                  "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-                  "requires": {
-                    "core-js": "2.5.3",
-                    "regenerator-runtime": "0.11.1"
-                  }
-                },
-                "babel-template": {
-                  "version": "6.26.0",
-                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-                  "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-                  "requires": {
-                    "babel-runtime": "6.26.0",
-                    "babel-traverse": "6.26.0",
-                    "babel-types": "6.26.0",
-                    "babylon": "6.18.0",
-                    "lodash": "4.17.5"
-                  }
-                },
-                "babel-traverse": {
-                  "version": "6.26.0",
-                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-                  "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-                  "requires": {
-                    "babel-code-frame": "6.26.0",
-                    "babel-messages": "6.23.0",
-                    "babel-runtime": "6.26.0",
-                    "babel-types": "6.26.0",
-                    "babylon": "6.18.0",
-                    "debug": "2.6.9",
-                    "globals": "9.18.0",
-                    "invariant": "2.2.3",
-                    "lodash": "4.17.5"
-                  }
-                },
-                "babel-types": {
-                  "version": "6.26.0",
-                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-                  "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-                  "requires": {
-                    "babel-runtime": "6.26.0",
-                    "esutils": "2.0.2",
-                    "lodash": "4.17.5",
-                    "to-fast-properties": "1.0.3"
-                  }
-                },
-                "babylon": {
-                  "version": "6.18.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-                  "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-                },
-                "balanced-match": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                  "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-                },
-                "base": {
-                  "version": "0.11.2",
-                  "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-                  "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-                  "requires": {
-                    "cache-base": "1.0.1",
-                    "class-utils": "0.3.6",
-                    "component-emitter": "1.2.1",
-                    "define-property": "1.0.0",
-                    "isobject": "3.0.1",
-                    "mixin-deep": "1.3.1",
-                    "pascalcase": "0.1.1"
-                  },
-                  "dependencies": {
-                    "define-property": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-                      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                      "requires": {
-                        "is-descriptor": "1.0.2"
-                      }
-                    },
-                    "isobject": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                    }
-                  }
-                },
-                "brace-expansion": {
-                  "version": "1.1.11",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-                  "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-                  "requires": {
-                    "balanced-match": "1.0.0",
-                    "concat-map": "0.0.1"
-                  }
-                },
-                "braces": {
-                  "version": "1.8.5",
-                  "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                  "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-                  "requires": {
-                    "expand-range": "1.8.2",
-                    "preserve": "0.2.0",
-                    "repeat-element": "1.1.2"
-                  }
-                },
-                "builtin-modules": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-                  "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-                },
-                "cache-base": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-                  "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-                  "requires": {
-                    "collection-visit": "1.0.0",
-                    "component-emitter": "1.2.1",
-                    "get-value": "2.0.6",
-                    "has-value": "1.0.0",
-                    "isobject": "3.0.1",
-                    "set-value": "2.0.0",
-                    "to-object-path": "0.3.0",
-                    "union-value": "1.0.0",
-                    "unset-value": "1.0.0"
-                  },
-                  "dependencies": {
-                    "isobject": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                    }
-                  }
-                },
-                "caching-transform": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-                  "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
-                  "requires": {
-                    "md5-hex": "1.3.0",
-                    "mkdirp": "0.5.1",
-                    "write-file-atomic": "1.3.4"
-                  }
-                },
-                "camelcase": {
-                  "version": "1.2.1",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                  "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-                  "optional": true
-                },
-                "center-align": {
-                  "version": "0.1.3",
-                  "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                  "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-                  "optional": true,
-                  "requires": {
-                    "align-text": "0.1.4",
-                    "lazy-cache": "1.0.4"
-                  }
-                },
-                "chalk": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                  "requires": {
-                    "ansi-styles": "2.2.1",
-                    "escape-string-regexp": "1.0.5",
-                    "has-ansi": "2.0.0",
-                    "strip-ansi": "3.0.1",
-                    "supports-color": "2.0.0"
-                  }
-                },
-                "class-utils": {
-                  "version": "0.3.6",
-                  "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-                  "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-                  "requires": {
-                    "arr-union": "3.1.0",
-                    "define-property": "0.2.5",
-                    "isobject": "3.0.1",
-                    "static-extend": "0.1.2"
-                  },
-                  "dependencies": {
-                    "define-property": {
-                      "version": "0.2.5",
-                      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                      "requires": {
-                        "is-descriptor": "0.1.6"
-                      }
-                    },
-                    "is-accessor-descriptor": {
-                      "version": "0.1.6",
-                      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-                      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-                      "requires": {
-                        "kind-of": "3.2.2"
-                      },
-                      "dependencies": {
-                        "kind-of": {
-                          "version": "3.2.2",
-                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                          "requires": {
-                            "is-buffer": "1.1.6"
-                          }
-                        }
-                      }
-                    },
-                    "is-data-descriptor": {
-                      "version": "0.1.4",
-                      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-                      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                      "requires": {
-                        "kind-of": "3.2.2"
-                      },
-                      "dependencies": {
-                        "kind-of": {
-                          "version": "3.2.2",
-                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                          "requires": {
-                            "is-buffer": "1.1.6"
-                          }
-                        }
-                      }
-                    },
-                    "is-descriptor": {
-                      "version": "0.1.6",
-                      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                      "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
-                      }
-                    },
-                    "isobject": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                    },
-                    "kind-of": {
-                      "version": "5.1.0",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-                    }
-                  }
-                },
-                "cliui": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                  "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-                  "optional": true,
-                  "requires": {
-                    "center-align": "0.1.3",
-                    "right-align": "0.1.3",
-                    "wordwrap": "0.0.2"
-                  },
-                  "dependencies": {
-                    "wordwrap": {
-                      "version": "0.0.2",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-                      "optional": true
-                    }
-                  }
-                },
-                "code-point-at": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-                },
-                "collection-visit": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-                  "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-                  "requires": {
-                    "map-visit": "1.0.0",
-                    "object-visit": "1.0.1"
-                  }
-                },
-                "commondir": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-                  "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
-                },
-                "component-emitter": {
-                  "version": "1.2.1",
-                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-                  "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-                },
-                "concat-map": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-                },
-                "convert-source-map": {
-                  "version": "1.5.1",
-                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-                  "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
-                },
-                "copy-descriptor": {
-                  "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-                  "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
-                },
-                "core-js": {
-                  "version": "2.5.3",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-                  "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
-                },
-                "cross-spawn": {
-                  "version": "4.0.2",
-                  "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-                  "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-                  "requires": {
-                    "lru-cache": "4.1.2",
-                    "which": "1.3.0"
-                  }
-                },
-                "debug": {
-                  "version": "2.6.9",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                  "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                  "requires": {
-                    "ms": "2.0.0"
-                  }
-                },
-                "debug-log": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-                  "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8="
-                },
-                "decamelize": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                  "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-                },
-                "decode-uri-component": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-                  "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-                },
-                "default-require-extensions": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-                  "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-                  "requires": {
-                    "strip-bom": "2.0.0"
-                  }
-                },
-                "define-property": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-                  "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-                  "requires": {
-                    "is-descriptor": "1.0.2",
-                    "isobject": "3.0.1"
-                  },
-                  "dependencies": {
-                    "isobject": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                    }
-                  }
-                },
-                "detect-indent": {
-                  "version": "4.0.0",
-                  "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-                  "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-                  "requires": {
-                    "repeating": "2.0.1"
-                  }
-                },
-                "error-ex": {
-                  "version": "1.3.1",
-                  "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-                  "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-                  "requires": {
-                    "is-arrayish": "0.2.1"
-                  }
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-                },
-                "esutils": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                  "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
-                },
-                "execa": {
-                  "version": "0.7.0",
-                  "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-                  "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-                  "requires": {
-                    "cross-spawn": "5.1.0",
-                    "get-stream": "3.0.0",
-                    "is-stream": "1.1.0",
-                    "npm-run-path": "2.0.2",
-                    "p-finally": "1.0.0",
-                    "signal-exit": "3.0.2",
-                    "strip-eof": "1.0.0"
-                  },
-                  "dependencies": {
-                    "cross-spawn": {
-                      "version": "5.1.0",
-                      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-                      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-                      "requires": {
-                        "lru-cache": "4.1.2",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.0"
-                      }
-                    }
-                  }
-                },
-                "expand-brackets": {
-                  "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                  "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-                  "requires": {
-                    "is-posix-bracket": "0.1.1"
-                  }
-                },
-                "expand-range": {
-                  "version": "1.8.2",
-                  "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-                  "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-                  "requires": {
-                    "fill-range": "2.2.3"
-                  }
-                },
-                "extend-shallow": {
-                  "version": "3.0.2",
-                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-                  "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-                  "requires": {
-                    "assign-symbols": "1.0.0",
-                    "is-extendable": "1.0.1"
-                  },
-                  "dependencies": {
-                    "is-extendable": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                      "requires": {
-                        "is-plain-object": "2.0.4"
-                      }
-                    }
-                  }
-                },
-                "extglob": {
-                  "version": "0.3.2",
-                  "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                  "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-                  "requires": {
-                    "is-extglob": "1.0.0"
-                  }
-                },
-                "filename-regex": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-                  "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
-                },
-                "fill-range": {
-                  "version": "2.2.3",
-                  "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-                  "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-                  "requires": {
-                    "is-number": "2.1.0",
-                    "isobject": "2.1.0",
-                    "randomatic": "1.1.7",
-                    "repeat-element": "1.1.2",
-                    "repeat-string": "1.6.1"
-                  }
-                },
-                "find-cache-dir": {
-                  "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-                  "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-                  "requires": {
-                    "commondir": "1.0.1",
-                    "mkdirp": "0.5.1",
-                    "pkg-dir": "1.0.0"
-                  }
-                },
-                "find-up": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-                  "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-                  "requires": {
-                    "locate-path": "2.0.0"
-                  }
-                },
-                "for-in": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-                  "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-                },
-                "for-own": {
-                  "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-                  "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-                  "requires": {
-                    "for-in": "1.0.2"
-                  }
-                },
-                "foreground-child": {
-                  "version": "1.5.6",
-                  "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-                  "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
-                  "requires": {
-                    "cross-spawn": "4.0.2",
-                    "signal-exit": "3.0.2"
-                  }
-                },
-                "fragment-cache": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-                  "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-                  "requires": {
-                    "map-cache": "0.2.2"
-                  }
-                },
-                "fs.realpath": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-                },
-                "get-caller-file": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-                  "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
-                },
-                "get-stream": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-                  "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-                },
-                "get-value": {
-                  "version": "2.0.6",
-                  "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-                  "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
-                },
-                "glob": {
-                  "version": "7.1.2",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                  "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-                  "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.4",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
-                  }
-                },
-                "glob-base": {
-                  "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-                  "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-                  "requires": {
-                    "glob-parent": "2.0.0",
-                    "is-glob": "2.0.1"
-                  }
-                },
-                "glob-parent": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                  "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                  "requires": {
-                    "is-glob": "2.0.1"
-                  }
-                },
-                "globals": {
-                  "version": "9.18.0",
-                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-                  "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-                },
-                "graceful-fs": {
-                  "version": "4.1.11",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                  "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-                },
-                "handlebars": {
-                  "version": "4.0.11",
-                  "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-                  "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-                  "requires": {
-                    "async": "1.5.2",
-                    "optimist": "0.6.1",
-                    "source-map": "0.4.4",
-                    "uglify-js": "2.8.29"
-                  },
-                  "dependencies": {
-                    "source-map": {
-                      "version": "0.4.4",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-                      "requires": {
-                        "amdefine": "1.0.1"
-                      }
-                    }
-                  }
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  }
-                },
-                "has-flag": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                  "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-                },
-                "has-value": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-                  "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-                  "requires": {
-                    "get-value": "2.0.6",
-                    "has-values": "1.0.0",
-                    "isobject": "3.0.1"
-                  },
-                  "dependencies": {
-                    "isobject": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                    }
-                  }
-                },
-                "has-values": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-                  "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-                  "requires": {
-                    "is-number": "3.0.0",
-                    "kind-of": "4.0.0"
-                  },
-                  "dependencies": {
-                    "is-number": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                      "requires": {
-                        "kind-of": "3.2.2"
-                      },
-                      "dependencies": {
-                        "kind-of": {
-                          "version": "3.2.2",
-                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                          "requires": {
-                            "is-buffer": "1.1.6"
-                          }
-                        }
-                      }
-                    },
-                    "kind-of": {
-                      "version": "4.0.0",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-                      "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                      "requires": {
-                        "is-buffer": "1.1.6"
-                      }
-                    }
-                  }
-                },
-                "hosted-git-info": {
-                  "version": "2.6.0",
-                  "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-                  "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
-                },
-                "imurmurhash": {
-                  "version": "0.1.4",
-                  "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-                  "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-                },
-                "inflight": {
-                  "version": "1.0.6",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                  "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-                  "requires": {
-                    "once": "1.4.0",
-                    "wrappy": "1.0.2"
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-                },
-                "invariant": {
-                  "version": "2.2.3",
-                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
-                  "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
-                  "requires": {
-                    "loose-envify": "1.3.1"
-                  }
-                },
-                "invert-kv": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-                  "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-                },
-                "is-accessor-descriptor": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                  "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                  "requires": {
-                    "kind-of": "6.0.2"
-                  },
-                  "dependencies": {
-                    "kind-of": {
-                      "version": "6.0.2",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-                    }
-                  }
-                },
-                "is-arrayish": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                  "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-                },
-                "is-buffer": {
-                  "version": "1.1.6",
-                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-                  "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-                },
-                "is-builtin-module": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                  "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-                  "requires": {
-                    "builtin-modules": "1.1.1"
-                  }
-                },
-                "is-data-descriptor": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                  "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                  "requires": {
-                    "kind-of": "6.0.2"
-                  },
-                  "dependencies": {
-                    "kind-of": {
-                      "version": "6.0.2",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-                    }
-                  }
-                },
-                "is-descriptor": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                  "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                  "requires": {
-                    "is-accessor-descriptor": "1.0.0",
-                    "is-data-descriptor": "1.0.0",
-                    "kind-of": "6.0.2"
-                  },
-                  "dependencies": {
-                    "kind-of": {
-                      "version": "6.0.2",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-                    }
-                  }
-                },
-                "is-dotfile": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-                  "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-                },
-                "is-equal-shallow": {
-                  "version": "0.1.3",
-                  "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-                  "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-                  "requires": {
-                    "is-primitive": "2.0.0"
-                  }
-                },
-                "is-extendable": {
-                  "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-                  "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
-                },
-                "is-extglob": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                  "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-                },
-                "is-finite": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-                  "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-                  "requires": {
-                    "number-is-nan": "1.0.1"
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-                },
-                "is-glob": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                  "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                  "requires": {
-                    "is-extglob": "1.0.0"
-                  }
-                },
-                "is-number": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                  "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-                  "requires": {
-                    "kind-of": "3.2.2"
-                  }
-                },
-                "is-odd": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-                  "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-                  "requires": {
-                    "is-number": "4.0.0"
-                  },
-                  "dependencies": {
-                    "is-number": {
-                      "version": "4.0.0",
-                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-                      "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
-                    }
-                  }
-                },
-                "is-plain-object": {
-                  "version": "2.0.4",
-                  "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-                  "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-                  "requires": {
-                    "isobject": "3.0.1"
-                  },
-                  "dependencies": {
-                    "isobject": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                    }
-                  }
-                },
-                "is-posix-bracket": {
-                  "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-                  "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-                },
-                "is-primitive": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-                  "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-                },
-                "is-stream": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-                  "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-                },
-                "is-utf8": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-                  "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-                },
-                "is-windows": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-                  "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-                },
-                "isexe": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-                  "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-                },
-                "isobject": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-                  "requires": {
-                    "isarray": "1.0.0"
-                  }
-                },
-                "istanbul-lib-coverage": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
-                  "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A=="
-                },
-                "istanbul-lib-hook": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
-                  "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
-                  "requires": {
-                    "append-transform": "0.4.0"
-                  }
-                },
-                "istanbul-lib-instrument": {
-                  "version": "1.10.1",
-                  "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
-                  "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
-                  "requires": {
-                    "babel-generator": "6.26.1",
-                    "babel-template": "6.26.0",
-                    "babel-traverse": "6.26.0",
-                    "babel-types": "6.26.0",
-                    "babylon": "6.18.0",
-                    "istanbul-lib-coverage": "1.2.0",
-                    "semver": "5.5.0"
-                  }
-                },
-                "istanbul-lib-report": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
-                  "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
-                  "requires": {
-                    "istanbul-lib-coverage": "1.2.0",
-                    "mkdirp": "0.5.1",
-                    "path-parse": "1.0.5",
-                    "supports-color": "3.2.3"
-                  },
-                  "dependencies": {
-                    "supports-color": {
-                      "version": "3.2.3",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                      "requires": {
-                        "has-flag": "1.0.0"
-                      }
-                    }
-                  }
-                },
-                "istanbul-lib-source-maps": {
-                  "version": "1.2.3",
-                  "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
-                  "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
-                  "requires": {
-                    "debug": "3.1.0",
-                    "istanbul-lib-coverage": "1.2.0",
-                    "mkdirp": "0.5.1",
-                    "rimraf": "2.6.2",
-                    "source-map": "0.5.7"
-                  },
-                  "dependencies": {
-                    "debug": {
-                      "version": "3.1.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                      "requires": {
-                        "ms": "2.0.0"
-                      }
-                    }
-                  }
-                },
-                "istanbul-reports": {
-                  "version": "1.3.0",
-                  "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
-                  "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
-                  "requires": {
-                    "handlebars": "4.0.11"
-                  }
-                },
-                "js-tokens": {
-                  "version": "3.0.2",
-                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-                  "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-                },
-                "jsesc": {
-                  "version": "1.3.0",
-                  "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-                  "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
-                },
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                },
-                "lazy-cache": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-                  "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-                  "optional": true
-                },
-                "lcid": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-                  "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-                  "requires": {
-                    "invert-kv": "1.0.0"
-                  }
-                },
-                "load-json-file": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                  "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-                  "requires": {
-                    "graceful-fs": "4.1.11",
-                    "parse-json": "2.2.0",
-                    "pify": "2.3.0",
-                    "pinkie-promise": "2.0.1",
-                    "strip-bom": "2.0.0"
-                  }
-                },
-                "locate-path": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-                  "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-                  "requires": {
-                    "p-locate": "2.0.0",
-                    "path-exists": "3.0.0"
-                  },
-                  "dependencies": {
-                    "path-exists": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-                      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "4.17.5",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-                  "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-                },
-                "longest": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
-                },
-                "loose-envify": {
-                  "version": "1.3.1",
-                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                  "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-                  "requires": {
-                    "js-tokens": "3.0.2"
-                  }
-                },
-                "lru-cache": {
-                  "version": "4.1.2",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-                  "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
-                  "requires": {
-                    "pseudomap": "1.0.2",
-                    "yallist": "2.1.2"
-                  }
-                },
-                "map-cache": {
-                  "version": "0.2.2",
-                  "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-                  "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
-                },
-                "map-visit": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-                  "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-                  "requires": {
-                    "object-visit": "1.0.1"
-                  }
-                },
-                "md5-hex": {
-                  "version": "1.3.0",
-                  "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-                  "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-                  "requires": {
-                    "md5-o-matic": "0.1.1"
-                  }
-                },
-                "md5-o-matic": {
-                  "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-                  "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
-                },
-                "mem": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-                  "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-                  "requires": {
-                    "mimic-fn": "1.2.0"
-                  }
-                },
-                "merge-source-map": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
-                  "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
-                  "requires": {
-                    "source-map": "0.6.1"
-                  },
-                  "dependencies": {
-                    "source-map": {
-                      "version": "0.6.1",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-                    }
-                  }
-                },
-                "micromatch": {
-                  "version": "2.3.11",
-                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                  "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-                  "requires": {
-                    "arr-diff": "2.0.0",
-                    "array-unique": "0.2.1",
-                    "braces": "1.8.5",
-                    "expand-brackets": "0.1.5",
-                    "extglob": "0.3.2",
-                    "filename-regex": "2.0.1",
-                    "is-extglob": "1.0.0",
-                    "is-glob": "2.0.1",
-                    "kind-of": "3.2.2",
-                    "normalize-path": "2.1.1",
-                    "object.omit": "2.0.1",
-                    "parse-glob": "3.0.4",
-                    "regex-cache": "0.4.4"
-                  }
-                },
-                "mimic-fn": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-                  "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
-                },
-                "minimatch": {
-                  "version": "3.0.4",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                  "requires": {
-                    "brace-expansion": "1.1.11"
-                  }
-                },
-                "minimist": {
-                  "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-                },
-                "mixin-deep": {
-                  "version": "1.3.1",
-                  "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-                  "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
-                  "requires": {
-                    "for-in": "1.0.2",
-                    "is-extendable": "1.0.1"
-                  },
-                  "dependencies": {
-                    "is-extendable": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                      "requires": {
-                        "is-plain-object": "2.0.4"
-                      }
-                    }
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-                  "requires": {
-                    "minimist": "0.0.8"
-                  }
-                },
-                "ms": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                  "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                },
-                "nanomatch": {
-                  "version": "1.2.9",
-                  "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-                  "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
-                  "requires": {
-                    "arr-diff": "4.0.0",
-                    "array-unique": "0.3.2",
-                    "define-property": "2.0.2",
-                    "extend-shallow": "3.0.2",
-                    "fragment-cache": "0.2.1",
-                    "is-odd": "2.0.0",
-                    "is-windows": "1.0.2",
-                    "kind-of": "6.0.2",
-                    "object.pick": "1.3.0",
-                    "regex-not": "1.0.2",
-                    "snapdragon": "0.8.2",
-                    "to-regex": "3.0.2"
-                  },
-                  "dependencies": {
-                    "arr-diff": {
-                      "version": "4.0.0",
-                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-                    },
-                    "array-unique": {
-                      "version": "0.3.2",
-                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-                    },
-                    "kind-of": {
-                      "version": "6.0.2",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-                    }
-                  }
-                },
-                "normalize-package-data": {
-                  "version": "2.4.0",
-                  "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-                  "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-                  "requires": {
-                    "hosted-git-info": "2.6.0",
-                    "is-builtin-module": "1.0.0",
-                    "semver": "5.5.0",
-                    "validate-npm-package-license": "3.0.3"
-                  }
-                },
-                "normalize-path": {
-                  "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-                  "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-                  "requires": {
-                    "remove-trailing-separator": "1.1.0"
-                  }
-                },
-                "npm-run-path": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-                  "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-                  "requires": {
-                    "path-key": "2.0.1"
-                  }
-                },
-                "number-is-nan": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                  "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-                },
-                "object-assign": {
-                  "version": "4.1.1",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-                },
-                "object-copy": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-                  "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-                  "requires": {
-                    "copy-descriptor": "0.1.1",
-                    "define-property": "0.2.5",
-                    "kind-of": "3.2.2"
-                  },
-                  "dependencies": {
-                    "define-property": {
-                      "version": "0.2.5",
-                      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                      "requires": {
-                        "is-descriptor": "0.1.6"
-                      }
-                    },
-                    "is-accessor-descriptor": {
-                      "version": "0.1.6",
-                      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-                      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-                      "requires": {
-                        "kind-of": "3.2.2"
-                      }
-                    },
-                    "is-data-descriptor": {
-                      "version": "0.1.4",
-                      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-                      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                      "requires": {
-                        "kind-of": "3.2.2"
-                      }
-                    },
-                    "is-descriptor": {
-                      "version": "0.1.6",
-                      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                      "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
-                      },
-                      "dependencies": {
-                        "kind-of": {
-                          "version": "5.1.0",
-                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-                        }
-                      }
-                    }
-                  }
-                },
-                "object-visit": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-                  "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-                  "requires": {
-                    "isobject": "3.0.1"
-                  },
-                  "dependencies": {
-                    "isobject": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                    }
-                  }
-                },
-                "object.omit": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-                  "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-                  "requires": {
-                    "for-own": "0.1.5",
-                    "is-extendable": "0.1.1"
-                  }
-                },
-                "object.pick": {
-                  "version": "1.3.0",
-                  "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-                  "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-                  "requires": {
-                    "isobject": "3.0.1"
-                  },
-                  "dependencies": {
-                    "isobject": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                  "requires": {
-                    "wrappy": "1.0.2"
-                  }
-                },
-                "optimist": {
-                  "version": "0.6.1",
-                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                  "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-                  "requires": {
-                    "minimist": "0.0.8",
-                    "wordwrap": "0.0.3"
-                  }
-                },
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                  "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-                },
-                "os-locale": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-                  "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-                  "requires": {
-                    "execa": "0.7.0",
-                    "lcid": "1.0.0",
-                    "mem": "1.1.0"
-                  }
-                },
-                "p-finally": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-                  "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-                },
-                "p-limit": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-                  "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-                  "requires": {
-                    "p-try": "1.0.0"
-                  }
-                },
-                "p-locate": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-                  "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-                  "requires": {
-                    "p-limit": "1.2.0"
-                  }
-                },
-                "p-try": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-                  "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-                },
-                "parse-glob": {
-                  "version": "3.0.4",
-                  "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-                  "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-                  "requires": {
-                    "glob-base": "0.3.0",
-                    "is-dotfile": "1.0.3",
-                    "is-extglob": "1.0.0",
-                    "is-glob": "2.0.1"
-                  }
-                },
-                "parse-json": {
-                  "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                  "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-                  "requires": {
-                    "error-ex": "1.3.1"
-                  }
-                },
-                "pascalcase": {
-                  "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-                  "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
-                },
-                "path-exists": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                  "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-                  "requires": {
-                    "pinkie-promise": "2.0.1"
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-                },
-                "path-key": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-                  "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-                },
-                "path-parse": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-                  "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
-                },
-                "path-type": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                  "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-                  "requires": {
-                    "graceful-fs": "4.1.11",
-                    "pify": "2.3.0",
-                    "pinkie-promise": "2.0.1"
-                  }
-                },
-                "pify": {
-                  "version": "2.3.0",
-                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-                },
-                "pinkie": {
-                  "version": "2.0.4",
-                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-                },
-                "pinkie-promise": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-                  "requires": {
-                    "pinkie": "2.0.4"
-                  }
-                },
-                "pkg-dir": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-                  "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-                  "requires": {
-                    "find-up": "1.1.2"
-                  },
-                  "dependencies": {
-                    "find-up": {
-                      "version": "1.1.2",
-                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-                      "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
-                      }
-                    }
-                  }
-                },
-                "posix-character-classes": {
-                  "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-                  "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
-                },
-                "preserve": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-                  "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-                },
-                "pseudomap": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-                  "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-                },
-                "randomatic": {
-                  "version": "1.1.7",
-                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-                  "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-                  "requires": {
-                    "is-number": "3.0.0",
-                    "kind-of": "4.0.0"
-                  },
-                  "dependencies": {
-                    "is-number": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                      "requires": {
-                        "kind-of": "3.2.2"
-                      },
-                      "dependencies": {
-                        "kind-of": {
-                          "version": "3.2.2",
-                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                          "requires": {
-                            "is-buffer": "1.1.6"
-                          }
-                        }
-                      }
-                    },
-                    "kind-of": {
-                      "version": "4.0.0",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-                      "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                      "requires": {
-                        "is-buffer": "1.1.6"
-                      }
-                    }
-                  }
-                },
-                "read-pkg": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                  "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-                  "requires": {
-                    "load-json-file": "1.1.0",
-                    "normalize-package-data": "2.4.0",
-                    "path-type": "1.1.0"
-                  }
-                },
-                "read-pkg-up": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                  "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-                  "requires": {
-                    "find-up": "1.1.2",
-                    "read-pkg": "1.1.0"
-                  },
-                  "dependencies": {
-                    "find-up": {
-                      "version": "1.1.2",
-                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-                      "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
-                      }
-                    }
-                  }
-                },
-                "regenerator-runtime": {
-                  "version": "0.11.1",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-                  "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-                },
-                "regex-cache": {
-                  "version": "0.4.4",
-                  "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-                  "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-                  "requires": {
-                    "is-equal-shallow": "0.1.3"
-                  }
-                },
-                "regex-not": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-                  "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-                  "requires": {
-                    "extend-shallow": "3.0.2",
-                    "safe-regex": "1.1.0"
-                  }
-                },
-                "remove-trailing-separator": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-                  "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
-                },
-                "repeat-element": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-                  "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
-                },
-                "repeat-string": {
-                  "version": "1.6.1",
-                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-                  "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-                },
-                "repeating": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-                  "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-                  "requires": {
-                    "is-finite": "1.0.2"
-                  }
-                },
-                "require-directory": {
-                  "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-                  "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-                },
-                "require-main-filename": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-                  "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-                },
-                "resolve-from": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-                  "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
-                },
-                "resolve-url": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-                  "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-                },
-                "ret": {
-                  "version": "0.1.15",
-                  "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-                  "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
-                },
-                "right-align": {
-                  "version": "0.1.3",
-                  "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                  "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-                  "optional": true,
-                  "requires": {
-                    "align-text": "0.1.4"
-                  }
-                },
-                "rimraf": {
-                  "version": "2.6.2",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-                  "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-                  "requires": {
-                    "glob": "7.1.2"
-                  }
-                },
-                "safe-regex": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-                  "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-                  "requires": {
-                    "ret": "0.1.15"
-                  }
-                },
-                "semver": {
-                  "version": "5.5.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-                  "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-                },
-                "set-value": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-                  "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-                  "requires": {
-                    "extend-shallow": "2.0.1",
-                    "is-extendable": "0.1.1",
-                    "is-plain-object": "2.0.4",
-                    "split-string": "3.1.0"
-                  },
-                  "dependencies": {
-                    "extend-shallow": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                      "requires": {
-                        "is-extendable": "0.1.1"
-                      }
-                    }
-                  }
-                },
-                "shebang-command": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-                  "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-                  "requires": {
-                    "shebang-regex": "1.0.0"
-                  }
-                },
-                "shebang-regex": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-                  "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-                },
-                "signal-exit": {
-                  "version": "3.0.2",
-                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                  "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-                },
-                "slide": {
-                  "version": "1.1.6",
-                  "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-                  "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
-                },
-                "snapdragon": {
-                  "version": "0.8.2",
-                  "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-                  "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-                  "requires": {
-                    "base": "0.11.2",
-                    "debug": "2.6.9",
-                    "define-property": "0.2.5",
-                    "extend-shallow": "2.0.1",
-                    "map-cache": "0.2.2",
-                    "source-map": "0.5.7",
-                    "source-map-resolve": "0.5.1",
-                    "use": "3.1.0"
-                  },
-                  "dependencies": {
-                    "define-property": {
-                      "version": "0.2.5",
-                      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                      "requires": {
-                        "is-descriptor": "0.1.6"
-                      }
-                    },
-                    "extend-shallow": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                      "requires": {
-                        "is-extendable": "0.1.1"
-                      }
-                    },
-                    "is-accessor-descriptor": {
-                      "version": "0.1.6",
-                      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-                      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-                      "requires": {
-                        "kind-of": "3.2.2"
-                      },
-                      "dependencies": {
-                        "kind-of": {
-                          "version": "3.2.2",
-                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                          "requires": {
-                            "is-buffer": "1.1.6"
-                          }
-                        }
-                      }
-                    },
-                    "is-data-descriptor": {
-                      "version": "0.1.4",
-                      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-                      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                      "requires": {
-                        "kind-of": "3.2.2"
-                      },
-                      "dependencies": {
-                        "kind-of": {
-                          "version": "3.2.2",
-                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                          "requires": {
-                            "is-buffer": "1.1.6"
-                          }
-                        }
-                      }
-                    },
-                    "is-descriptor": {
-                      "version": "0.1.6",
-                      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                      "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
-                      }
-                    },
-                    "kind-of": {
-                      "version": "5.1.0",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-                    }
-                  }
-                },
-                "snapdragon-node": {
-                  "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-                  "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-                  "requires": {
-                    "define-property": "1.0.0",
-                    "isobject": "3.0.1",
-                    "snapdragon-util": "3.0.1"
-                  },
-                  "dependencies": {
-                    "define-property": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-                      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                      "requires": {
-                        "is-descriptor": "1.0.2"
-                      }
-                    },
-                    "isobject": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                    }
-                  }
-                },
-                "snapdragon-util": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-                  "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-                  "requires": {
-                    "kind-of": "3.2.2"
-                  }
-                },
-                "source-map": {
-                  "version": "0.5.7",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                  "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-                },
-                "source-map-resolve": {
-                  "version": "0.5.1",
-                  "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-                  "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
-                  "requires": {
-                    "atob": "2.0.3",
-                    "decode-uri-component": "0.2.0",
-                    "resolve-url": "0.2.1",
-                    "source-map-url": "0.4.0",
-                    "urix": "0.1.0"
-                  }
-                },
-                "source-map-url": {
-                  "version": "0.4.0",
-                  "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-                  "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
-                },
-                "spawn-wrap": {
-                  "version": "1.4.2",
-                  "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
-                  "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
-                  "requires": {
-                    "foreground-child": "1.5.6",
-                    "mkdirp": "0.5.1",
-                    "os-homedir": "1.0.2",
-                    "rimraf": "2.6.2",
-                    "signal-exit": "3.0.2",
-                    "which": "1.3.0"
-                  }
-                },
-                "spdx-correct": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-                  "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
-                  "requires": {
-                    "spdx-expression-parse": "3.0.0",
-                    "spdx-license-ids": "3.0.0"
-                  }
-                },
-                "spdx-exceptions": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-                  "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
-                },
-                "spdx-expression-parse": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-                  "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-                  "requires": {
-                    "spdx-exceptions": "2.1.0",
-                    "spdx-license-ids": "3.0.0"
-                  }
-                },
-                "spdx-license-ids": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-                  "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
-                },
-                "split-string": {
-                  "version": "3.1.0",
-                  "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-                  "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-                  "requires": {
-                    "extend-shallow": "3.0.2"
-                  }
-                },
-                "static-extend": {
-                  "version": "0.1.2",
-                  "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-                  "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-                  "requires": {
-                    "define-property": "0.2.5",
-                    "object-copy": "0.1.0"
-                  },
-                  "dependencies": {
-                    "define-property": {
-                      "version": "0.2.5",
-                      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                      "requires": {
-                        "is-descriptor": "0.1.6"
-                      }
-                    },
-                    "is-accessor-descriptor": {
-                      "version": "0.1.6",
-                      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-                      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-                      "requires": {
-                        "kind-of": "3.2.2"
-                      },
-                      "dependencies": {
-                        "kind-of": {
-                          "version": "3.2.2",
-                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                          "requires": {
-                            "is-buffer": "1.1.6"
-                          }
-                        }
-                      }
-                    },
-                    "is-data-descriptor": {
-                      "version": "0.1.4",
-                      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-                      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                      "requires": {
-                        "kind-of": "3.2.2"
-                      },
-                      "dependencies": {
-                        "kind-of": {
-                          "version": "3.2.2",
-                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                          "requires": {
-                            "is-buffer": "1.1.6"
-                          }
-                        }
-                      }
-                    },
-                    "is-descriptor": {
-                      "version": "0.1.6",
-                      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                      "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
-                      }
-                    },
-                    "kind-of": {
-                      "version": "5.1.0",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-                    }
-                  }
-                },
-                "string-width": {
-                  "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                  "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                  "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-                    },
-                    "strip-ansi": {
-                      "version": "4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                      "requires": {
-                        "ansi-regex": "3.0.0"
-                      }
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  }
-                },
-                "strip-bom": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                  "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-                  "requires": {
-                    "is-utf8": "0.2.1"
-                  }
-                },
-                "strip-eof": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-                  "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-                },
-                "test-exclude": {
-                  "version": "4.2.1",
-                  "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
-                  "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
-                  "requires": {
-                    "arrify": "1.0.1",
-                    "micromatch": "3.1.9",
-                    "object-assign": "4.1.1",
-                    "read-pkg-up": "1.0.1",
-                    "require-main-filename": "1.0.1"
-                  },
-                  "dependencies": {
-                    "arr-diff": {
-                      "version": "4.0.0",
-                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-                    },
-                    "array-unique": {
-                      "version": "0.3.2",
-                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-                    },
-                    "braces": {
-                      "version": "2.3.1",
-                      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
-                      "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
-                      "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "kind-of": "6.0.2",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
-                      },
-                      "dependencies": {
-                        "define-property": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-                          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                          "requires": {
-                            "is-descriptor": "1.0.2"
-                          }
-                        },
-                        "extend-shallow": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                          "requires": {
-                            "is-extendable": "0.1.1"
-                          }
-                        }
-                      }
-                    },
-                    "expand-brackets": {
-                      "version": "2.1.4",
-                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-                      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-                      "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
-                      },
-                      "dependencies": {
-                        "define-property": {
-                          "version": "0.2.5",
-                          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                          "requires": {
-                            "is-descriptor": "0.1.6"
-                          }
-                        },
-                        "extend-shallow": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                          "requires": {
-                            "is-extendable": "0.1.1"
-                          }
-                        },
-                        "is-descriptor": {
-                          "version": "0.1.6",
-                          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                          "requires": {
-                            "is-accessor-descriptor": "0.1.6",
-                            "is-data-descriptor": "0.1.4",
-                            "kind-of": "5.1.0"
-                          }
-                        },
-                        "kind-of": {
-                          "version": "5.1.0",
-                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-                        }
-                      }
-                    },
-                    "extglob": {
-                      "version": "2.0.4",
-                      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-                      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-                      "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
-                      },
-                      "dependencies": {
-                        "define-property": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-                          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                          "requires": {
-                            "is-descriptor": "1.0.2"
-                          }
-                        },
-                        "extend-shallow": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                          "requires": {
-                            "is-extendable": "0.1.1"
-                          }
-                        }
-                      }
-                    },
-                    "fill-range": {
-                      "version": "4.0.0",
-                      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                      "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
-                      },
-                      "dependencies": {
-                        "extend-shallow": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                          "requires": {
-                            "is-extendable": "0.1.1"
-                          }
-                        }
-                      }
-                    },
-                    "is-accessor-descriptor": {
-                      "version": "0.1.6",
-                      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-                      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-                      "requires": {
-                        "kind-of": "3.2.2"
-                      },
-                      "dependencies": {
-                        "kind-of": {
-                          "version": "3.2.2",
-                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                          "requires": {
-                            "is-buffer": "1.1.6"
-                          }
-                        }
-                      }
-                    },
-                    "is-data-descriptor": {
-                      "version": "0.1.4",
-                      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-                      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                      "requires": {
-                        "kind-of": "3.2.2"
-                      },
-                      "dependencies": {
-                        "kind-of": {
-                          "version": "3.2.2",
-                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                          "requires": {
-                            "is-buffer": "1.1.6"
-                          }
-                        }
-                      }
-                    },
-                    "is-number": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                      "requires": {
-                        "kind-of": "3.2.2"
-                      },
-                      "dependencies": {
-                        "kind-of": {
-                          "version": "3.2.2",
-                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                          "requires": {
-                            "is-buffer": "1.1.6"
-                          }
-                        }
-                      }
-                    },
-                    "isobject": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                    },
-                    "kind-of": {
-                      "version": "6.0.2",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-                    },
-                    "micromatch": {
-                      "version": "3.1.9",
-                      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
-                      "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
-                      "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.1",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.9",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
-                      }
-                    }
-                  }
-                },
-                "to-fast-properties": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-                  "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
-                },
-                "to-object-path": {
-                  "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-                  "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-                  "requires": {
-                    "kind-of": "3.2.2"
-                  }
-                },
-                "to-regex": {
-                  "version": "3.0.2",
-                  "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-                  "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-                  "requires": {
-                    "define-property": "2.0.2",
-                    "extend-shallow": "3.0.2",
-                    "regex-not": "1.0.2",
-                    "safe-regex": "1.1.0"
-                  }
-                },
-                "to-regex-range": {
-                  "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-                  "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-                  "requires": {
-                    "is-number": "3.0.0",
-                    "repeat-string": "1.6.1"
-                  },
-                  "dependencies": {
-                    "is-number": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                      "requires": {
-                        "kind-of": "3.2.2"
-                      }
-                    }
-                  }
-                },
-                "trim-right": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-                  "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
-                },
-                "uglify-js": {
-                  "version": "2.8.29",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-                  "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-                  "optional": true,
-                  "requires": {
-                    "source-map": "0.5.7",
-                    "uglify-to-browserify": "1.0.2",
-                    "yargs": "3.10.0"
-                  },
-                  "dependencies": {
-                    "yargs": {
-                      "version": "3.10.0",
-                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-                      "optional": true,
-                      "requires": {
-                        "camelcase": "1.2.1",
-                        "cliui": "2.1.0",
-                        "decamelize": "1.2.0",
-                        "window-size": "0.1.0"
-                      }
-                    }
-                  }
-                },
-                "uglify-to-browserify": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                  "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-                  "optional": true
-                },
-                "union-value": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-                  "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-                  "requires": {
-                    "arr-union": "3.1.0",
-                    "get-value": "2.0.6",
-                    "is-extendable": "0.1.1",
-                    "set-value": "0.4.3"
-                  },
-                  "dependencies": {
-                    "extend-shallow": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                      "requires": {
-                        "is-extendable": "0.1.1"
-                      }
-                    },
-                    "set-value": {
-                      "version": "0.4.3",
-                      "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-                      "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-                      "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
-                      }
-                    }
-                  }
-                },
-                "unset-value": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-                  "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-                  "requires": {
-                    "has-value": "0.3.1",
-                    "isobject": "3.0.1"
-                  },
-                  "dependencies": {
-                    "has-value": {
-                      "version": "0.3.1",
-                      "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-                      "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-                      "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
-                      },
-                      "dependencies": {
-                        "isobject": {
-                          "version": "2.1.0",
-                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-                          "requires": {
-                            "isarray": "1.0.0"
-                          }
-                        }
-                      }
-                    },
-                    "has-values": {
-                      "version": "0.1.4",
-                      "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-                      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-                    },
-                    "isobject": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                    }
-                  }
-                },
-                "urix": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-                  "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
-                },
-                "use": {
-                  "version": "3.1.0",
-                  "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-                  "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-                  "requires": {
-                    "kind-of": "6.0.2"
-                  },
-                  "dependencies": {
-                    "kind-of": {
-                      "version": "6.0.2",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-                    }
-                  }
-                },
-                "validate-npm-package-license": {
-                  "version": "3.0.3",
-                  "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-                  "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
-                  "requires": {
-                    "spdx-correct": "3.0.0",
-                    "spdx-expression-parse": "3.0.0"
-                  }
-                },
-                "which": {
-                  "version": "1.3.0",
-                  "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-                  "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-                  "requires": {
-                    "isexe": "2.0.0"
-                  }
-                },
-                "which-module": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-                  "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-                },
-                "window-size": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                  "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-                  "optional": true
-                },
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                  "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-                },
-                "wrap-ansi": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-                  "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-                  "requires": {
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1"
-                  },
-                  "dependencies": {
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                      "requires": {
-                        "number-is-nan": "1.0.1"
-                      }
-                    },
-                    "string-width": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                      "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                      }
-                    }
-                  }
-                },
-                "wrappy": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-                },
-                "write-file-atomic": {
-                  "version": "1.3.4",
-                  "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-                  "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-                  "requires": {
-                    "graceful-fs": "4.1.11",
-                    "imurmurhash": "0.1.4",
-                    "slide": "1.1.6"
-                  }
-                },
-                "y18n": {
-                  "version": "3.2.1",
-                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-                  "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-                },
-                "yallist": {
-                  "version": "2.1.2",
-                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-                  "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-                },
-                "yargs": {
-                  "version": "11.1.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-                  "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
-                  "requires": {
-                    "cliui": "4.0.0",
-                    "decamelize": "1.2.0",
-                    "find-up": "2.1.0",
-                    "get-caller-file": "1.0.2",
-                    "os-locale": "2.1.0",
-                    "require-directory": "2.1.1",
-                    "require-main-filename": "1.0.1",
-                    "set-blocking": "2.0.0",
-                    "string-width": "2.1.1",
-                    "which-module": "2.0.0",
-                    "y18n": "3.2.1",
-                    "yargs-parser": "9.0.2"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-                    },
-                    "camelcase": {
-                      "version": "4.1.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-                    },
-                    "cliui": {
-                      "version": "4.0.0",
-                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-                      "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
-                      "requires": {
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "wrap-ansi": "2.1.0"
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                      "requires": {
-                        "ansi-regex": "3.0.0"
-                      }
-                    },
-                    "yargs-parser": {
-                      "version": "9.0.2",
-                      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-                      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-                      "requires": {
-                        "camelcase": "4.1.0"
-                      }
-                    }
-                  }
-                },
-                "yargs-parser": {
-                  "version": "8.1.0",
-                  "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-                  "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
-                  "requires": {
-                    "camelcase": "4.1.0"
-                  },
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "4.1.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-                    }
-                  }
-                }
-              }
-            },
-            "rimraf": {
-              "version": "2.6.2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-              "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-              "requires": {
-                "glob": "7.0.6"
-              }
-            }
-          }
-        },
-        "tap-mocha-reporter": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.7.tgz",
-          "integrity": "sha512-GHVXJ38C3oPRpM3YUc43JlGdpVZYiKeT1fmAd3HH2+J+ZWwsNAUFvRRdoGsXLw9+gU9o+zXpBqhS/oXyRQYwlA==",
-          "requires": {
-            "color-support": "1.1.3",
-            "debug": "2.6.9",
-            "diff": "1.4.0",
-            "escape-string-regexp": "1.0.5",
-            "glob": "7.0.6",
-            "js-yaml": "3.6.1",
-            "readable-stream": "2.3.5",
-            "tap-parser": "5.4.0",
-            "unicode-length": "1.0.3"
-          },
-          "dependencies": {
-            "process-nextick-args": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-              "optional": true
-            },
-            "readable-stream": {
-              "version": "2.3.5",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
-              "optional": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "optional": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tap-parser": {
-              "version": "5.4.0",
-              "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
-              "integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
-              "requires": {
-                "events-to-array": "1.1.2",
-                "js-yaml": "3.6.1",
-                "readable-stream": "2.3.5"
-              }
-            }
-          }
-        },
-        "tap-parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
-          "integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
-          "requires": {
-            "events-to-array": "1.1.2",
-            "js-yaml": "3.6.1",
-            "minipass": "2.2.4"
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
-        },
-        "through": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-        },
-        "tmatch": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-3.1.0.tgz",
-          "integrity": "sha512-W3MSATOCN4pVu2qFxmJLIArSifeSOFqnfx9hiUaVgOmeRoI2NbU7RNga+6G+L8ojlFeQge+ZPCclWyUpQ8UeNQ=="
-        },
-        "topo": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-          "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-          "requires": {
-            "punycode": "1.4.1"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-            }
-          }
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
-        },
-        "trivial-deferred": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
-          "integrity": "sha1-N21NKdlR1jaKb3oK6FwvTV4GWPM="
-        },
-        "tsame": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/tsame/-/tsame-1.1.2.tgz",
-          "integrity": "sha512-ovCs24PGjmByVPr9tSIOs/yjUX9sJl0grEmOsj9dZA/UknQkgPOKcUqM84aSCvt9awHuhc/boMzTg3BHFalxWw=="
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-          "optional": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-          "requires": {
-            "prelude-ls": "1.1.2"
-          }
-        },
-        "typedarray": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-        },
-        "underscore.string": {
-          "version": "3.3.4",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
-          "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
-          "requires": {
-            "sprintf-js": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "unicode-length": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
-          "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
-          "requires": {
-            "punycode": "1.4.1",
-            "strip-ansi": "3.0.1"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-            }
-          }
-        },
-        "user-home": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-          "requires": {
-            "os-homedir": "1.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-        },
-        "uuid": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-          "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
-          "requires": {
-            "spdx-correct": "3.0.0",
-            "spdx-expression-parse": "3.0.0"
-          }
-        },
-        "verror": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
-        },
-        "walk": {
-          "version": "2.3.9",
-          "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz",
-          "integrity": "sha1-MbTbZnjyrgHDnqn7hyWpAx5Vins=",
-          "requires": {
-            "foreachasync": "3.0.0"
-          }
-        },
-        "which": {
-          "version": "1.2.14",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-          "requires": {
-            "isexe": "2.0.0"
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-        },
-        "write": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-          "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-          "requires": {
-            "mkdirp": "0.5.1"
-          }
-        },
-        "write-file-atomic": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-          "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-        },
-        "yapool": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/yapool/-/yapool-1.0.0.tgz",
-          "integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o="
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
         }
       }
     },
@@ -8983,8 +2161,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -8997,6 +2174,14 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "isemail": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
+      "integrity": "sha512-zfRhJn9rFSGhzU5tGZqepRSAj3+g6oTOHxMGGriWNJZzyLPUK8H7VHpqKntegnW8KLyGA9zwuNaCoopl40LTpg==",
+      "requires": {
+        "punycode": "2.1.0"
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -9006,8 +2191,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jackpot": {
       "version": "0.0.6",
@@ -9015,6 +2199,16 @@
       "integrity": "sha1-PP8GQoXL9m9OqyWTyQvOgWqCGEk=",
       "requires": {
         "retry": "0.6.0"
+      }
+    },
+    "joi": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.3.0.tgz",
+      "integrity": "sha512-iF6jEYVfBIoYXztYymia1JfuoVbxBNuOcwdbsdoGin9/jjhBLhonKmfTQOvePss8r8v4tU4JOcNmYPHZzKEFag==",
+      "requires": {
+        "hoek": "5.0.3",
+        "isemail": "3.1.2",
+        "topo": "3.0.0"
       }
     },
     "js-yaml": {
@@ -9039,7 +2233,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
       "optional": true
     },
     "json-parse-better-errors": {
@@ -9051,14 +2244,12 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -9101,26 +2292,11 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-          "dev": true
-        }
       }
     },
     "keep-alive-agent": {
@@ -9470,14 +2646,12 @@
     "mime-db": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-      "dev": true
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
     },
     "mime-types": {
       "version": "2.1.18",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-      "dev": true,
       "requires": {
         "mime-db": "1.33.0"
       }
@@ -9979,8 +3153,7 @@
       "dependencies": {
         "append-transform": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "default-require-extensions": "1.0.0"
@@ -9988,14 +3161,12 @@
         },
         "arrify": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "bundled": true,
           "dev": true
         },
         "caching-transform": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "md5-hex": "1.3.0",
@@ -10005,8 +3176,7 @@
           "dependencies": {
             "write-file-atomic": {
               "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
-              "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "graceful-fs": "4.1.4",
@@ -10016,20 +3186,17 @@
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.4",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                  "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
+                  "bundled": true,
                   "dev": true
                 },
                 "imurmurhash": {
                   "version": "0.1.4",
-                  "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-                  "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+                  "bundled": true,
                   "dev": true
                 },
                 "slide": {
                   "version": "1.1.6",
-                  "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-                  "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -10038,14 +3205,12 @@
         },
         "convert-source-map": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz",
-          "integrity": "sha1-RMCMJQbxD7PKb9iI1aNETPjWpmk=",
+          "bundled": true,
           "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "strip-bom": "2.0.0"
@@ -10053,8 +3218,7 @@
           "dependencies": {
             "strip-bom": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-utf8": "0.2.1"
@@ -10062,8 +3226,7 @@
               "dependencies": {
                 "is-utf8": {
                   "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-                  "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -10072,8 +3235,7 @@
         },
         "find-cache-dir": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "commondir": "1.0.1",
@@ -10083,14 +3245,12 @@
           "dependencies": {
             "commondir": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-              "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+              "bundled": true,
               "dev": true
             },
             "pkg-dir": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-              "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "find-up": "1.1.2"
@@ -10100,8 +3260,7 @@
         },
         "find-up": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "path-exists": "2.1.0",
@@ -10110,8 +3269,7 @@
           "dependencies": {
             "path-exists": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-              "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "pinkie-promise": "2.0.1"
@@ -10119,8 +3277,7 @@
             },
             "pinkie-promise": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "pinkie": "2.0.4"
@@ -10128,8 +3285,7 @@
               "dependencies": {
                 "pinkie": {
                   "version": "2.0.4",
-                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -10138,8 +3294,7 @@
         },
         "foreground-child": {
           "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.1.tgz",
-          "integrity": "sha1-76NNl4DSV8dQsR4pbi4e3BT/+qo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cross-spawn-async": "2.2.4",
@@ -10149,8 +3304,7 @@
           "dependencies": {
             "cross-spawn-async": {
               "version": "2.2.4",
-              "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.4.tgz",
-              "integrity": "sha1-yajY6aBlAsekYpbjOhoFS10vGBI=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lru-cache": "4.0.1",
@@ -10159,8 +3313,7 @@
               "dependencies": {
                 "lru-cache": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-                  "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "pseudomap": "1.0.2",
@@ -10169,14 +3322,12 @@
                   "dependencies": {
                     "pseudomap": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-                      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+                      "bundled": true,
                       "dev": true
                     },
                     "yallist": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
-                      "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -10185,14 +3336,12 @@
             },
             "signal-exit": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
-              "integrity": "sha1-N1h5sfkuvDszRIDQONxUam1VhWQ=",
+              "bundled": true,
               "dev": true
             },
             "which": {
               "version": "1.2.10",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
-              "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "isexe": "1.1.2"
@@ -10200,8 +3349,7 @@
               "dependencies": {
                 "isexe": {
                   "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-                  "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -10210,8 +3358,7 @@
         },
         "glob": {
           "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-          "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inflight": "1.0.5",
@@ -10223,8 +3370,7 @@
           "dependencies": {
             "inflight": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-              "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "once": "1.3.3",
@@ -10233,22 +3379,19 @@
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+              "bundled": true,
               "dev": true
             },
             "minimatch": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "brace-expansion": "1.1.4"
@@ -10256,8 +3399,7 @@
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.4",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
-                  "integrity": "sha1-RkogTHf0gsCFwqNsRWu/uvtnoSc=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "balanced-match": "0.4.1",
@@ -10266,14 +3408,12 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.4.1",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                      "integrity": "sha1-GQU+LgdI6ts3nabAnUVc9eEDkzU=",
+                      "bundled": true,
                       "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -10282,8 +3422,7 @@
             },
             "once": {
               "version": "1.3.3",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "wrappy": "1.0.2"
@@ -10291,24 +3430,21 @@
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "istanbul": {
           "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.3.tgz",
-          "integrity": "sha1-W3FO4K5JOsXvIEuZ84crzu9z1To=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "abbrev": "1.0.7",
@@ -10329,20 +3465,17 @@
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-              "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
+              "bundled": true,
               "dev": true
             },
             "async": {
               "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+              "bundled": true,
               "dev": true
             },
             "escodegen": {
               "version": "1.8.0",
-              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.0.tgz",
-              "integrity": "sha1-skaq6CnOc9WeLFVyc1nt0cEwqBs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "esprima": "2.7.2",
@@ -10354,20 +3487,17 @@
               "dependencies": {
                 "estraverse": {
                   "version": "1.9.3",
-                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-                  "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+                  "bundled": true,
                   "dev": true
                 },
                 "esutils": {
                   "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                  "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+                  "bundled": true,
                   "dev": true
                 },
                 "optionator": {
                   "version": "0.8.1",
-                  "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
-                  "integrity": "sha1-4xtJMs3V+4Yqiw0QvGPT7h7H14s=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "deep-is": "0.1.3",
@@ -10380,20 +3510,17 @@
                   "dependencies": {
                     "deep-is": {
                       "version": "0.1.3",
-                      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-                      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "fast-levenshtein": {
                       "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz",
-                      "integrity": "sha1-KuezKrweYS2kik4ThJuIii9h5+k=",
+                      "bundled": true,
                       "dev": true
                     },
                     "levn": {
                       "version": "0.3.0",
-                      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "prelude-ls": "1.1.2",
@@ -10402,14 +3529,12 @@
                     },
                     "prelude-ls": {
                       "version": "1.1.2",
-                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "type-check": {
                       "version": "0.3.2",
-                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "prelude-ls": "1.1.2"
@@ -10419,8 +3544,7 @@
                 },
                 "source-map": {
                   "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-                  "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -10429,8 +3553,7 @@
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -10440,14 +3563,12 @@
             },
             "esprima": {
               "version": "2.7.2",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-              "integrity": "sha1-9DvlQ2CZhOrkTJM6xjNSpq818zk=",
+              "bundled": true,
               "dev": true
             },
             "fileset": {
               "version": "0.2.1",
-              "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
-              "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "glob": "5.0.15",
@@ -10456,8 +3577,7 @@
               "dependencies": {
                 "glob": {
                   "version": "5.0.15",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                  "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "inflight": "1.0.5",
@@ -10469,8 +3589,7 @@
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-                      "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "once": "1.3.3",
@@ -10479,30 +3598,26 @@
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                      "bundled": true,
                       "dev": true
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "brace-expansion": "1.1.4"
@@ -10510,8 +3625,7 @@
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.4",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
-                      "integrity": "sha1-RkogTHf0gsCFwqNsRWu/uvtnoSc=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "balanced-match": "0.4.1",
@@ -10520,14 +3634,12 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.1",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                          "integrity": "sha1-GQU+LgdI6ts3nabAnUVc9eEDkzU=",
+                          "bundled": true,
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -10538,8 +3650,7 @@
             },
             "handlebars": {
               "version": "4.0.5",
-              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
-              "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "async": "1.5.2",
@@ -10550,8 +3661,7 @@
               "dependencies": {
                 "optimist": {
                   "version": "0.6.1",
-                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                  "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "minimist": "0.0.10",
@@ -10560,22 +3670,19 @@
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.10",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                      "bundled": true,
                       "dev": true
                     },
                     "wordwrap": {
                       "version": "0.0.3",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.4.4",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                  "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "amdefine": "1.0.0"
@@ -10583,16 +3690,14 @@
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "uglify-js": {
                   "version": "2.6.2",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
-                  "integrity": "sha1-9QvoikLNOWpiUdxSqzcvccwS/vA=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -10604,29 +3709,25 @@
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-                      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "source-map": {
                       "version": "0.5.6",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "uglify-to-browserify": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "yargs": {
                       "version": "3.10.0",
-                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "requires": {
@@ -10638,15 +3739,13 @@
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "cliui": {
                           "version": "2.1.0",
-                          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -10657,8 +3756,7 @@
                           "dependencies": {
                             "center-align": {
                               "version": "0.1.3",
-                              "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                              "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+                              "bundled": true,
                               "dev": true,
                               "optional": true,
                               "requires": {
@@ -10668,8 +3766,7 @@
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                                  "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                                  "bundled": true,
                                   "dev": true,
                                   "optional": true,
                                   "requires": {
@@ -10680,8 +3777,7 @@
                                   "dependencies": {
                                     "kind-of": {
                                       "version": "3.0.3",
-                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
-                                      "integrity": "sha1-xhYIdH2BWwNiVW2zJ2Nip6OK3tM=",
+                                      "bundled": true,
                                       "dev": true,
                                       "optional": true,
                                       "requires": {
@@ -10690,8 +3786,7 @@
                                       "dependencies": {
                                         "is-buffer": {
                                           "version": "1.1.3",
-                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
-                                          "integrity": "sha1-24l/w/esotUN6UtsjCiWpHcWJ68=",
+                                          "bundled": true,
                                           "dev": true,
                                           "optional": true
                                         }
@@ -10699,15 +3794,13 @@
                                     },
                                     "longest": {
                                       "version": "1.0.1",
-                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                      "bundled": true,
                                       "dev": true,
                                       "optional": true
                                     },
                                     "repeat-string": {
                                       "version": "1.5.4",
-                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-                                      "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                                      "bundled": true,
                                       "dev": true,
                                       "optional": true
                                     }
@@ -10715,8 +3808,7 @@
                                 },
                                 "lazy-cache": {
                                   "version": "1.0.4",
-                                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-                                  "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+                                  "bundled": true,
                                   "dev": true,
                                   "optional": true
                                 }
@@ -10724,8 +3816,7 @@
                             },
                             "right-align": {
                               "version": "0.1.3",
-                              "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                              "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                              "bundled": true,
                               "dev": true,
                               "optional": true,
                               "requires": {
@@ -10734,8 +3825,7 @@
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                                  "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                                  "bundled": true,
                                   "dev": true,
                                   "optional": true,
                                   "requires": {
@@ -10746,8 +3836,7 @@
                                   "dependencies": {
                                     "kind-of": {
                                       "version": "3.0.3",
-                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
-                                      "integrity": "sha1-xhYIdH2BWwNiVW2zJ2Nip6OK3tM=",
+                                      "bundled": true,
                                       "dev": true,
                                       "optional": true,
                                       "requires": {
@@ -10756,8 +3845,7 @@
                                       "dependencies": {
                                         "is-buffer": {
                                           "version": "1.1.3",
-                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
-                                          "integrity": "sha1-24l/w/esotUN6UtsjCiWpHcWJ68=",
+                                          "bundled": true,
                                           "dev": true,
                                           "optional": true
                                         }
@@ -10765,15 +3853,13 @@
                                     },
                                     "longest": {
                                       "version": "1.0.1",
-                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                      "bundled": true,
                                       "dev": true,
                                       "optional": true
                                     },
                                     "repeat-string": {
                                       "version": "1.5.4",
-                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-                                      "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                                      "bundled": true,
                                       "dev": true,
                                       "optional": true
                                     }
@@ -10783,8 +3869,7 @@
                             },
                             "wordwrap": {
                               "version": "0.0.2",
-                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                              "bundled": true,
                               "dev": true,
                               "optional": true
                             }
@@ -10792,15 +3877,13 @@
                         },
                         "decamelize": {
                           "version": "1.2.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "window-size": {
                           "version": "0.1.0",
-                          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         }
@@ -10812,8 +3895,7 @@
             },
             "js-yaml": {
               "version": "3.6.1",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-              "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "argparse": "1.0.7",
@@ -10822,8 +3904,7 @@
               "dependencies": {
                 "argparse": {
                   "version": "1.0.7",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
-                  "integrity": "sha1-wolQZIBVeBDxSovGLXoG9j7X+VE=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "sprintf-js": "1.0.3"
@@ -10831,8 +3912,7 @@
                   "dependencies": {
                     "sprintf-js": {
                       "version": "1.0.3",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -10841,8 +3921,7 @@
             },
             "nopt": {
               "version": "3.0.6",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "abbrev": "1.0.7"
@@ -10850,8 +3929,7 @@
             },
             "once": {
               "version": "1.3.3",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "wrappy": "1.0.2"
@@ -10859,22 +3937,19 @@
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "resolve": {
               "version": "1.1.7",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-              "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+              "bundled": true,
               "dev": true
             },
             "supports-color": {
               "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-              "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "has-flag": "1.0.0"
@@ -10882,16 +3957,14 @@
               "dependencies": {
                 "has-flag": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                  "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "which": {
               "version": "1.2.10",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
-              "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "isexe": "1.1.2"
@@ -10899,24 +3972,21 @@
               "dependencies": {
                 "isexe": {
                   "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-                  "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "wordwrap": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "md5-hex": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "md5-o-matic": "0.1.1"
@@ -10924,16 +3994,14 @@
           "dependencies": {
             "md5-o-matic": {
               "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-              "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "micromatch": {
           "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.8.tgz",
-          "integrity": "sha1-lPv4837Z7eyga/HI97dD+19vWFQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-diff": "2.0.0",
@@ -10953,8 +4021,7 @@
           "dependencies": {
             "arr-diff": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-              "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "arr-flatten": "1.0.1"
@@ -10962,22 +4029,19 @@
               "dependencies": {
                 "arr-flatten": {
                   "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-                  "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "array-unique": {
               "version": "0.2.1",
-              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-              "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+              "bundled": true,
               "dev": true
             },
             "braces": {
               "version": "1.8.5",
-              "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-              "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "expand-range": "1.8.2",
@@ -10987,8 +4051,7 @@
               "dependencies": {
                 "expand-range": {
                   "version": "1.8.2",
-                  "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-                  "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "fill-range": "2.2.3"
@@ -10996,8 +4059,7 @@
                   "dependencies": {
                     "fill-range": {
                       "version": "2.2.3",
-                      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-                      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "is-number": "2.1.0",
@@ -11009,8 +4071,7 @@
                       "dependencies": {
                         "is-number": {
                           "version": "2.1.0",
-                          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "kind-of": "3.0.3"
@@ -11018,8 +4079,7 @@
                         },
                         "isobject": {
                           "version": "2.1.0",
-                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "isarray": "1.0.0"
@@ -11027,16 +4087,14 @@
                           "dependencies": {
                             "isarray": {
                               "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
                         },
                         "randomatic": {
                           "version": "1.1.5",
-                          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-                          "integrity": "sha1-Xp718tVzxnvSuBJK6QtRVuRXhAs=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "is-number": "2.1.0",
@@ -11045,8 +4103,7 @@
                         },
                         "repeat-string": {
                           "version": "1.5.4",
-                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-                          "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -11055,22 +4112,19 @@
                 },
                 "preserve": {
                   "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-                  "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+                  "bundled": true,
                   "dev": true
                 },
                 "repeat-element": {
                   "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-                  "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "expand-brackets": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-              "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-posix-bracket": "0.1.1"
@@ -11078,16 +4132,14 @@
               "dependencies": {
                 "is-posix-bracket": {
                   "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-                  "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "extglob": {
               "version": "0.3.2",
-              "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-              "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extglob": "1.0.0"
@@ -11095,20 +4147,17 @@
             },
             "filename-regex": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-              "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U=",
+              "bundled": true,
               "dev": true
             },
             "is-extglob": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+              "bundled": true,
               "dev": true
             },
             "is-glob": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extglob": "1.0.0"
@@ -11116,8 +4165,7 @@
             },
             "kind-of": {
               "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
-              "integrity": "sha1-xhYIdH2BWwNiVW2zJ2Nip6OK3tM=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-buffer": "1.1.3"
@@ -11125,22 +4173,19 @@
               "dependencies": {
                 "is-buffer": {
                   "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
-                  "integrity": "sha1-24l/w/esotUN6UtsjCiWpHcWJ68=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "normalize-path": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-              "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o=",
+              "bundled": true,
               "dev": true
             },
             "object.omit": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-              "integrity": "sha1-hoWXMz1U5gZilAu0WGBd1q4S/pQ=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "for-own": "0.1.4",
@@ -11149,8 +4194,7 @@
               "dependencies": {
                 "for-own": {
                   "version": "0.1.4",
-                  "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-                  "integrity": "sha1-AUm0GjkIjHUV9R6+HBOG1F+TUHI=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "for-in": "0.1.5"
@@ -11158,24 +4202,21 @@
                   "dependencies": {
                     "for-in": {
                       "version": "0.1.5",
-                      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz",
-                      "integrity": "sha1-AHN04rbVxnQgoUeb23WgSHK3OMQ=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "is-extendable": {
                   "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-                  "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "parse-glob": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-              "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "glob-base": "0.3.0",
@@ -11186,8 +4227,7 @@
               "dependencies": {
                 "glob-base": {
                   "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-                  "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "glob-parent": "2.0.0",
@@ -11196,8 +4236,7 @@
                   "dependencies": {
                     "glob-parent": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "is-glob": "2.0.1"
@@ -11207,16 +4246,14 @@
                 },
                 "is-dotfile": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-                  "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "regex-cache": {
               "version": "0.4.3",
-              "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-              "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-equal-shallow": "0.1.3",
@@ -11225,8 +4262,7 @@
               "dependencies": {
                 "is-equal-shallow": {
                   "version": "0.1.3",
-                  "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-                  "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-primitive": "2.0.0"
@@ -11234,8 +4270,7 @@
                 },
                 "is-primitive": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-                  "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -11244,8 +4279,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -11253,16 +4287,14 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "pkg-up": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
-          "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "find-up": "1.1.2"
@@ -11270,14 +4302,12 @@
         },
         "resolve-from": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "bundled": true,
           "dev": true
         },
         "rimraf": {
           "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-          "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "7.0.3"
@@ -11285,20 +4315,17 @@
         },
         "signal-exit": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
-          "integrity": "sha1-PAVDtl17T7xgts2UWT2b9DZzm+g=",
+          "bundled": true,
           "dev": true
         },
         "source-map": {
           "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "bundled": true,
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.2.3.tgz",
-          "integrity": "sha1-3300R/tKAZYZpB9o7mQqcY5gYuk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "foreground-child": "1.5.1",
@@ -11311,20 +4338,17 @@
           "dependencies": {
             "os-homedir": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-              "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
+              "bundled": true,
               "dev": true
             },
             "signal-exit": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
-              "integrity": "sha1-N1h5sfkuvDszRIDQONxUam1VhWQ=",
+              "bundled": true,
               "dev": true
             },
             "which": {
               "version": "1.2.10",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
-              "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "isexe": "1.1.2"
@@ -11332,8 +4356,7 @@
               "dependencies": {
                 "isexe": {
                   "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-                  "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -11342,8 +4365,7 @@
         },
         "test-exclude": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-1.1.0.tgz",
-          "integrity": "sha1-9d3XGJJ7Ev0C8nCgqpOc627qQVE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arrify": "1.0.1",
@@ -11355,8 +4377,7 @@
           "dependencies": {
             "lodash.assign": {
               "version": "4.0.9",
-              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.9.tgz",
-              "integrity": "sha1-Cgcx2TWQ3dm6RYn61lqvbuCSF+M=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lodash.keys": "4.0.7",
@@ -11365,22 +4386,19 @@
               "dependencies": {
                 "lodash.keys": {
                   "version": "4.0.7",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.7.tgz",
-                  "integrity": "sha1-MOGzvZjlTWoGEZkYEmhba8R8tjs=",
+                  "bundled": true,
                   "dev": true
                 },
                 "lodash.rest": {
                   "version": "4.0.3",
-                  "resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.3.tgz",
-                  "integrity": "sha1-TBwyxAAoCHJQ+r9w1C4BUVSPSMU=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "read-pkg-up": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "find-up": "1.1.2",
@@ -11389,8 +4407,7 @@
               "dependencies": {
                 "read-pkg": {
                   "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                  "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "load-json-file": "1.1.0",
@@ -11400,8 +4417,7 @@
                   "dependencies": {
                     "load-json-file": {
                       "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "graceful-fs": "4.1.4",
@@ -11413,14 +4429,12 @@
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.4",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
+                          "bundled": true,
                           "dev": true
                         },
                         "parse-json": {
                           "version": "2.2.0",
-                          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "error-ex": "1.3.0"
@@ -11428,8 +4442,7 @@
                           "dependencies": {
                             "error-ex": {
                               "version": "1.3.0",
-                              "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                              "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "is-arrayish": "0.2.1"
@@ -11437,8 +4450,7 @@
                               "dependencies": {
                                 "is-arrayish": {
                                   "version": "0.2.1",
-                                  "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                                  "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+                                  "bundled": true,
                                   "dev": true
                                 }
                               }
@@ -11447,14 +4459,12 @@
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                          "bundled": true,
                           "dev": true
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "pinkie": "2.0.4"
@@ -11462,16 +4472,14 @@
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
                         },
                         "strip-bom": {
                           "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "is-utf8": "0.2.1"
@@ -11479,8 +4487,7 @@
                           "dependencies": {
                             "is-utf8": {
                               "version": "0.2.1",
-                              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-                              "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -11489,8 +4496,7 @@
                     },
                     "normalize-package-data": {
                       "version": "2.3.5",
-                      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-                      "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "hosted-git-info": "2.1.5",
@@ -11501,14 +4507,12 @@
                       "dependencies": {
                         "hosted-git-info": {
                           "version": "2.1.5",
-                          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-                          "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
+                          "bundled": true,
                           "dev": true
                         },
                         "is-builtin-module": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "builtin-modules": "1.1.1"
@@ -11516,22 +4520,19 @@
                           "dependencies": {
                             "builtin-modules": {
                               "version": "1.1.1",
-                              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-                              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
                         },
                         "semver": {
                           "version": "5.1.0",
-                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-                          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
+                          "bundled": true,
                           "dev": true
                         },
                         "validate-npm-package-license": {
                           "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "spdx-correct": "1.0.2",
@@ -11540,8 +4541,7 @@
                           "dependencies": {
                             "spdx-correct": {
                               "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "spdx-license-ids": "1.2.1"
@@ -11549,16 +4549,14 @@
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
-                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
-                                  "integrity": "sha1-0H6hek0v2TUfnZTi/5zsdBgP6PM=",
+                                  "bundled": true,
                                   "dev": true
                                 }
                               }
                             },
                             "spdx-expression-parse": {
                               "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                              "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "spdx-exceptions": "1.0.4",
@@ -11567,14 +4565,12 @@
                               "dependencies": {
                                 "spdx-exceptions": {
                                   "version": "1.0.4",
-                                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-                                  "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0=",
+                                  "bundled": true,
                                   "dev": true
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
-                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
-                                  "integrity": "sha1-0H6hek0v2TUfnZTi/5zsdBgP6PM=",
+                                  "bundled": true,
                                   "dev": true
                                 }
                               }
@@ -11585,8 +4581,7 @@
                     },
                     "path-type": {
                       "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "graceful-fs": "4.1.4",
@@ -11596,20 +4591,17 @@
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.4",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
+                          "bundled": true,
                           "dev": true
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                          "bundled": true,
                           "dev": true
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "pinkie": "2.0.4"
@@ -11617,8 +4609,7 @@
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -11631,16 +4622,14 @@
             },
             "require-main-filename": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "yargs": {
           "version": "4.7.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.7.1.tgz",
-          "integrity": "sha1-5gQyZYozh/8mnAKOrN5KUS5Djf8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "camelcase": "3.0.0",
@@ -11660,14 +4649,12 @@
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+              "bundled": true,
               "dev": true
             },
             "cliui": {
               "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "string-width": "1.0.1",
@@ -11677,8 +4664,7 @@
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ansi-regex": "2.0.0"
@@ -11686,16 +4672,14 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "wrap-ansi": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-                  "integrity": "sha1-fTD4+HP5pbvDpk2ryNF34HGuQm8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "string-width": "1.0.1"
@@ -11705,14 +4689,12 @@
             },
             "decamelize": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+              "bundled": true,
               "dev": true
             },
             "lodash.assign": {
               "version": "4.0.9",
-              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.9.tgz",
-              "integrity": "sha1-Cgcx2TWQ3dm6RYn61lqvbuCSF+M=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lodash.keys": "4.0.7",
@@ -11721,22 +4703,19 @@
               "dependencies": {
                 "lodash.keys": {
                   "version": "4.0.7",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.7.tgz",
-                  "integrity": "sha1-MOGzvZjlTWoGEZkYEmhba8R8tjs=",
+                  "bundled": true,
                   "dev": true
                 },
                 "lodash.rest": {
                   "version": "4.0.3",
-                  "resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.3.tgz",
-                  "integrity": "sha1-TBwyxAAoCHJQ+r9w1C4BUVSPSMU=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "os-locale": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-              "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lcid": "1.0.0"
@@ -11744,8 +4723,7 @@
               "dependencies": {
                 "lcid": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-                  "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "invert-kv": "1.0.0"
@@ -11753,8 +4731,7 @@
                   "dependencies": {
                     "invert-kv": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-                      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -11763,8 +4740,7 @@
             },
             "pkg-conf": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
-              "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "find-up": "1.1.2",
@@ -11775,8 +4751,7 @@
               "dependencies": {
                 "load-json-file": {
                   "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                  "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "graceful-fs": "4.1.4",
@@ -11788,14 +4763,12 @@
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.4",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                      "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
+                      "bundled": true,
                       "dev": true
                     },
                     "parse-json": {
                       "version": "2.2.0",
-                      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "error-ex": "1.3.0"
@@ -11803,8 +4776,7 @@
                       "dependencies": {
                         "error-ex": {
                           "version": "1.3.0",
-                          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                          "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "is-arrayish": "0.2.1"
@@ -11812,8 +4784,7 @@
                           "dependencies": {
                             "is-arrayish": {
                               "version": "0.2.1",
-                              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                              "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -11822,14 +4793,12 @@
                     },
                     "pify": {
                       "version": "2.3.0",
-                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                      "bundled": true,
                       "dev": true
                     },
                     "pinkie-promise": {
                       "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "pinkie": "2.0.4"
@@ -11837,16 +4806,14 @@
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "strip-bom": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "is-utf8": "0.2.1"
@@ -11854,8 +4821,7 @@
                       "dependencies": {
                         "is-utf8": {
                           "version": "0.2.1",
-                          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-                          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
@@ -11864,22 +4830,19 @@
                 },
                 "object-assign": {
                   "version": "4.1.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                  "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+                  "bundled": true,
                   "dev": true
                 },
                 "symbol": {
                   "version": "0.2.3",
-                  "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz",
-                  "integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "read-pkg-up": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "find-up": "1.1.2",
@@ -11888,8 +4851,7 @@
               "dependencies": {
                 "read-pkg": {
                   "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                  "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "load-json-file": "1.1.0",
@@ -11899,8 +4861,7 @@
                   "dependencies": {
                     "load-json-file": {
                       "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "graceful-fs": "4.1.4",
@@ -11912,14 +4873,12 @@
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.4",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
+                          "bundled": true,
                           "dev": true
                         },
                         "parse-json": {
                           "version": "2.2.0",
-                          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "error-ex": "1.3.0"
@@ -11927,8 +4886,7 @@
                           "dependencies": {
                             "error-ex": {
                               "version": "1.3.0",
-                              "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                              "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "is-arrayish": "0.2.1"
@@ -11936,8 +4894,7 @@
                               "dependencies": {
                                 "is-arrayish": {
                                   "version": "0.2.1",
-                                  "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                                  "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+                                  "bundled": true,
                                   "dev": true
                                 }
                               }
@@ -11946,14 +4903,12 @@
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                          "bundled": true,
                           "dev": true
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "pinkie": "2.0.4"
@@ -11961,16 +4916,14 @@
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
                         },
                         "strip-bom": {
                           "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "is-utf8": "0.2.1"
@@ -11978,8 +4931,7 @@
                           "dependencies": {
                             "is-utf8": {
                               "version": "0.2.1",
-                              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-                              "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -11988,8 +4940,7 @@
                     },
                     "normalize-package-data": {
                       "version": "2.3.5",
-                      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-                      "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "hosted-git-info": "2.1.5",
@@ -12000,14 +4951,12 @@
                       "dependencies": {
                         "hosted-git-info": {
                           "version": "2.1.5",
-                          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-                          "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
+                          "bundled": true,
                           "dev": true
                         },
                         "is-builtin-module": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "builtin-modules": "1.1.1"
@@ -12015,22 +4964,19 @@
                           "dependencies": {
                             "builtin-modules": {
                               "version": "1.1.1",
-                              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-                              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
                         },
                         "semver": {
                           "version": "5.1.0",
-                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-                          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
+                          "bundled": true,
                           "dev": true
                         },
                         "validate-npm-package-license": {
                           "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "spdx-correct": "1.0.2",
@@ -12039,8 +4985,7 @@
                           "dependencies": {
                             "spdx-correct": {
                               "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "spdx-license-ids": "1.2.1"
@@ -12048,16 +4993,14 @@
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
-                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
-                                  "integrity": "sha1-0H6hek0v2TUfnZTi/5zsdBgP6PM=",
+                                  "bundled": true,
                                   "dev": true
                                 }
                               }
                             },
                             "spdx-expression-parse": {
                               "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                              "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
+                              "bundled": true,
                               "dev": true,
                               "requires": {
                                 "spdx-exceptions": "1.0.4",
@@ -12066,14 +5009,12 @@
                               "dependencies": {
                                 "spdx-exceptions": {
                                   "version": "1.0.4",
-                                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-                                  "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0=",
+                                  "bundled": true,
                                   "dev": true
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
-                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
-                                  "integrity": "sha1-0H6hek0v2TUfnZTi/5zsdBgP6PM=",
+                                  "bundled": true,
                                   "dev": true
                                 }
                               }
@@ -12084,8 +5025,7 @@
                     },
                     "path-type": {
                       "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "graceful-fs": "4.1.4",
@@ -12095,20 +5035,17 @@
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.4",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
+                          "bundled": true,
                           "dev": true
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                          "bundled": true,
                           "dev": true
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                          "bundled": true,
                           "dev": true,
                           "requires": {
                             "pinkie": "2.0.4"
@@ -12116,8 +5053,7 @@
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -12130,20 +5066,17 @@
             },
             "require-main-filename": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+              "bundled": true,
               "dev": true
             },
             "set-blocking": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-1.0.0.tgz",
-              "integrity": "sha1-zV5dk4BI3xrJLf6S4fFq3WVvXsU=",
+              "bundled": true,
               "dev": true
             },
             "string-width": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-              "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "code-point-at": "1.0.0",
@@ -12153,8 +5086,7 @@
               "dependencies": {
                 "code-point-at": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                  "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "number-is-nan": "1.0.0"
@@ -12162,16 +5094,14 @@
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "number-is-nan": "1.0.0"
@@ -12179,16 +5109,14 @@
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ansi-regex": "2.0.0"
@@ -12196,8 +5124,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -12206,20 +5133,17 @@
             },
             "window-size": {
               "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-              "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+              "bundled": true,
               "dev": true
             },
             "y18n": {
               "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+              "bundled": true,
               "dev": true
             },
             "yargs-parser": {
               "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.0.tgz",
-              "integrity": "sha1-HzZ9ycbPpWYLaXEjDzsnf8Xjrco=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "camelcase": "2.1.1",
@@ -12228,8 +5152,7 @@
               "dependencies": {
                 "camelcase": {
                   "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-                  "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -12241,8 +5164,7 @@
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -12392,8 +5314,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "2.3.0",
@@ -12468,10 +5389,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
     },
     "q": {
       "version": "1.5.1",
@@ -12480,9 +5400,9 @@
       "dev": true
     },
     "qs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
-      "integrity": "sha1-0OmudFIzoS3EP7TzBVu6RGJhFTw="
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -12500,6 +5420,13 @@
         "stack-trace": "0.0.9",
         "timed-out": "4.0.1",
         "uuid": "3.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
+          "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg="
+        }
       }
     },
     "read-pkg": {
@@ -12579,7 +5506,6 @@
       "version": "2.85.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
-      "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.7.0",
@@ -12603,136 +5529,6 @@
         "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
         "uuid": "3.2.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-          "dev": true
-        },
-        "boom": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-          "dev": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-              "dev": true,
-              "requires": {
-                "hoek": "4.2.1"
-              }
-            }
-          }
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-          "dev": true,
-          "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-          "dev": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.1",
-            "sntp": "2.1.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.1"
-          }
-        },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-          "dev": true
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.2"
-          }
-        },
-        "uuid": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-          "dev": true
-        }
       }
     },
     "require-uncached": {
@@ -12801,15 +5597,45 @@
         "verror": "1.10.0"
       },
       "dependencies": {
+        "asn1": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
+        },
+        "assert-plus": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
+        },
+        "http-signature": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+          "integrity": "sha1-F5bPZ6ABrVzWhJ3KCZFIXwkIn+Y=",
+          "requires": {
+            "asn1": "0.1.11",
+            "assert-plus": "0.1.5",
+            "ctype": "0.5.3"
+          }
+        },
         "node-uuid": {
           "version": "1.4.8",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
           "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
         },
+        "qs": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
+          "integrity": "sha1-0OmudFIzoS3EP7TzBVu6RGJhFTw="
+        },
         "semver": {
           "version": "4.3.6",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
         }
       }
     },
@@ -12821,6 +5647,16 @@
         "restify": "4.3.3"
       },
       "dependencies": {
+        "asn1": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
+        },
+        "assert-plus": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
+        },
         "dtrace-provider": {
           "version": "0.8.6",
           "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.6.tgz",
@@ -12830,10 +5666,15 @@
             "nan": "2.10.0"
           }
         },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        "http-signature": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+          "integrity": "sha1-F5bPZ6ABrVzWhJ3KCZFIXwkIn+Y=",
+          "requires": {
+            "asn1": "0.1.11",
+            "assert-plus": "0.1.5",
+            "ctype": "0.5.3"
+          }
         },
         "restify": {
           "version": "4.3.3",
@@ -12867,10 +5708,10 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
         },
-        "uuid": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
         }
       }
     },
@@ -12963,12 +5804,18 @@
       "dev": true
     },
     "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "4.2.1"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+        }
       }
     },
     "source-map": {
@@ -13114,7 +5961,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
-      "dev": true,
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -13124,20 +5970,6 @@
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
-      },
-      "dependencies": {
-        "asn1": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-          "dev": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "stack-trace": {
@@ -13175,8 +6007,7 @@
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -13231,6 +6062,16 @@
         "string-width": "2.1.1"
       },
       "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -13487,13 +6328,27 @@
       "integrity": "sha1-DFYkbzPzDaG409colauvFmYPOM8=",
       "dev": true
     },
+    "topo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+      "requires": {
+        "hoek": "5.0.3"
+      }
+    },
     "tough-cookie": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-      "dev": true,
       "requires": {
         "punycode": "1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
       }
     },
     "trim-newlines": {
@@ -13503,15 +6358,17 @@
       "dev": true
     },
     "tunnel-agent": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
     },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
       "optional": true
     },
     "type-check": {
@@ -13573,6 +6430,14 @@
       "requires": {
         "punycode": "1.4.1",
         "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
       }
     },
     "user-home": {
@@ -13590,9 +6455,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
-      "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.3",
@@ -13627,6 +6492,11 @@
         "verror": "1.6.0"
       },
       "dependencies": {
+        "extsprintf": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
+          "integrity": "sha1-WtlGwi9bMrp/jNdCZxHG6KP8JSk="
+        },
         "verror": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
@@ -13644,14 +6514,7 @@
       "requires": {
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.2.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
+        "extsprintf": "1.3.0"
       }
     },
     "walk": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "csv-parse": "1.0.4",
     "deep-equal": "1.0.1",
     "ip": "1.1.3",
-    "ip-reputation-js-client": "2.2.0",
+    "ip-reputation-js-client": "3.0.1",
     "lodash.isequal": "4.5.0",
     "lodash.merge": "4.6.0",
     "memcached": "2.2.1",


### PR DESCRIPTION
As discussed in backend meeting earlier today, this updates ip-reputation-js-client to latest release, in preparation for train-112 cut.

The shrinkwrap diff seems to have a fair bit of churn, but all I did was:

* `rm -rf node_modules npm-shrinkwrap.json`
* Update `package.json`
* `npm install`
* `npm run shrinkwrap`

So maybe this is expected?

/cc @shane-tomlinson for train-112 cut.