### PR TITLE
fix(deps): update ip rep client to v4

### DIFF
--- a/lib/reputationService.js
+++ b/lib/reputationService.js
@@ -30,8 +30,8 @@ var get = function (log, ipClient, ip) {
   return ipClient.get(ip)
     .then(function (response) {
       if (response && response.body && response.statusCode === 200) {
-        log.info({ op: 'fetchIPReputation', ip: ip, reputation: response.body.Reputation })
-        return response.body.Reputation
+        log.info({ op: 'fetchIPReputation', ip: ip, reputation: response.body.reputation })
+        return response.body.reputation
       }
 
       if (response.statusCode === 404) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-1.0.5.tgz",
       "integrity": "sha512-1zTojq9gW2mi0YblGrS86gCyL56+gbCn6o2+1UJJL3pFmBgp8IAMzZ93PkHHtdrbL3BnVMBrD2Q2WR32FbhIAg==",
       "requires": {
-        "methods": "^1.1.2"
+        "methods": "1.1.2"
       }
     },
     "@newrelic/native-metrics": {
@@ -18,7 +18,7 @@
       "integrity": "sha512-6Pv2Z9vkinr0MTnH1BORBs/SFOdKei43tQo2z30h9NtTc1pmWb/n5VWjgp7ReZ7FwzTI2oIhjbgnk2gZzpl6bw==",
       "optional": true,
       "requires": {
-        "nan": "^2.8.0"
+        "nan": "2.10.0"
       }
     },
     "@tyriar/fibonacci-heap": {
@@ -32,8 +32,8 @@
       "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
       "dev": true,
       "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
       }
     },
     "abbrev": {
@@ -54,7 +54,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "^3.0.4"
+        "acorn": "3.3.0"
       },
       "dependencies": {
         "acorn": {
@@ -76,7 +76,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
       "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
       "requires": {
-        "es6-promisify": "^5.0.0"
+        "es6-promisify": "5.0.0"
       }
     },
     "ajv": {
@@ -85,8 +85,8 @@
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "json-stable-stringify": "^1.0.1"
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
       }
     },
     "ajv-keywords": {
@@ -125,7 +125,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "array-differ": {
@@ -152,7 +152,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -182,7 +182,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
-        "lodash": "^4.14.0"
+        "lodash": "4.17.10"
       }
     },
     "asynckit": {
@@ -206,7 +206,7 @@
       "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
       "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
       "requires": {
-        "precond": "0.2"
+        "precond": "0.2.3"
       }
     },
     "balanced-match": {
@@ -220,7 +220,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "bl": {
@@ -228,7 +228,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
       "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
       "requires": {
-        "readable-stream": "~2.0.5"
+        "readable-stream": "2.0.6"
       }
     },
     "bluebird": {
@@ -242,7 +242,7 @@
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
       "requires": {
-        "hoek": "2.x.x"
+        "hoek": "2.16.3"
       }
     },
     "brace-expansion": {
@@ -250,7 +250,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -270,10 +270,10 @@
       "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.0.tgz",
       "integrity": "sha1-ik1MwduxRPUpjrhsEEMak0+N8FM=",
       "requires": {
-        "dtrace-provider": "~0.6",
-        "moment": "^2.10.6",
-        "mv": "~2",
-        "safe-json-stringify": "~1"
+        "dtrace-provider": "0.6.0",
+        "moment": "2.22.1",
+        "mv": "2.1.1",
+        "safe-json-stringify": "1.1.0"
       }
     },
     "caller-path": {
@@ -282,7 +282,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "^0.2.0"
+        "callsites": "0.2.0"
       }
     },
     "callsites": {
@@ -302,8 +302,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       },
       "dependencies": {
         "camelcase": {
@@ -326,11 +326,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "circular-json": {
@@ -351,7 +351,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^1.0.1"
+        "restore-cursor": "1.0.1"
       }
     },
     "cli-width": {
@@ -394,7 +394,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -409,8 +409,8 @@
       "integrity": "sha1-hZTw/98j/AIfpRdheQvpvCctI68=",
       "dev": true,
       "requires": {
-        "array-ify": "^1.0.0",
-        "dot-prop": "^2.0.0"
+        "array-ify": "1.0.0",
+        "dot-prop": "2.4.0"
       }
     },
     "concat-map": {
@@ -423,10 +423,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -439,13 +439,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -453,7 +453,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -469,20 +469,20 @@
       "integrity": "sha1-vzy+TukOCPhuOfa431SBkWgM7QI=",
       "dev": true,
       "requires": {
-        "add-stream": "^1.0.0",
-        "compare-func": "^1.3.1",
-        "conventional-changelog-writer": "^0.2.0",
+        "add-stream": "1.0.0",
+        "compare-func": "1.3.1",
+        "conventional-changelog-writer": "0.2.1",
         "conventional-commits-parser": "0.0.19",
-        "dateformat": "^1.0.11",
-        "get-pkg-repo": "^0.1.0",
+        "dateformat": "1.0.12",
+        "get-pkg-repo": "0.1.0",
         "git-raw-commits": "0.1.0",
-        "git-semver-tags": "^1.0.0",
-        "lodash": "^3.9.3",
-        "meow": "^3.3.0",
-        "q": "^1.4.1",
-        "semver": "^5.0.1",
-        "tempfile": "^1.1.1",
-        "through2": "^2.0.0"
+        "git-semver-tags": "1.3.6",
+        "lodash": "3.10.1",
+        "meow": "3.7.0",
+        "q": "1.5.1",
+        "semver": "5.5.0",
+        "tempfile": "1.1.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "lodash": {
@@ -499,15 +499,15 @@
       "integrity": "sha1-XyMr7xTcigMznN4UFNjfyl0AINI=",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
-        "conventional-commits-filter": "^0.1.0",
-        "dateformat": "^1.0.11",
-        "handlebars": "^3.0.3",
-        "lodash": "^3.8.0",
-        "meow": "^3.3.0",
-        "semver": "^5.0.1",
-        "split": "^1.0.0",
-        "through2": "^2.0.0"
+        "compare-func": "1.3.1",
+        "conventional-commits-filter": "0.1.1",
+        "dateformat": "1.0.12",
+        "handlebars": "3.0.3",
+        "lodash": "3.10.1",
+        "meow": "3.7.0",
+        "semver": "5.5.0",
+        "split": "1.0.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "lodash": {
@@ -524,8 +524,8 @@
       "integrity": "sha1-2dJsdZn4nePSScuj3veRH8UcDas=",
       "dev": true,
       "requires": {
-        "is-subset": "^0.1.1",
-        "modify-values": "^1.0.0"
+        "is-subset": "0.1.1",
+        "modify-values": "1.0.1"
       }
     },
     "conventional-commits-parser": {
@@ -534,12 +534,12 @@
       "integrity": "sha1-G9IRiZUVaXph6iYOLElbY9F8E28=",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.4",
-        "is-text-path": "^1.0.0",
-        "lodash": "^3.3.1",
-        "meow": "^3.3.0",
-        "split": "^1.0.0",
-        "through2": "^2.0.0"
+        "JSONStream": "1.3.2",
+        "is-text-path": "1.0.1",
+        "lodash": "3.10.1",
+        "meow": "3.7.0",
+        "split": "1.0.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "lodash": {
@@ -612,9 +612,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         },
         "http-signature": {
@@ -623,9 +623,9 @@
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.1"
           }
         },
         "js-yaml": {
@@ -634,8 +634,8 @@
           "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^2.6.0"
+            "argparse": "1.0.10",
+            "esprima": "2.7.3"
           }
         },
         "minimist": {
@@ -656,26 +656,26 @@
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.3.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1",
-            "uuid": "^3.0.0"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.7.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.0.0"
           }
         },
         "tough-cookie": {
@@ -684,7 +684,7 @@
           "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
           "dev": true,
           "requires": {
-            "punycode": "^1.4.1"
+            "punycode": "1.4.1"
           }
         }
       }
@@ -695,8 +695,8 @@
       "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.3",
+        "which": "1.2.14"
       }
     },
     "cryptiles": {
@@ -705,7 +705,7 @@
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
       "requires": {
-        "boom": "2.x.x"
+        "boom": "2.10.1"
       }
     },
     "csv": {
@@ -713,10 +713,10 @@
       "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.6.tgz",
       "integrity": "sha1-jbrn3f26rmLB6ph8Pg+Kmsc3tz0=",
       "requires": {
-        "csv-generate": "^0.0.6",
-        "csv-parse": "^1.0.0",
-        "csv-stringify": "^0.0.8",
-        "stream-transform": "^0.1.0"
+        "csv-generate": "0.0.6",
+        "csv-parse": "1.0.4",
+        "csv-stringify": "0.0.8",
+        "stream-transform": "0.1.2"
       }
     },
     "csv-generate": {
@@ -745,7 +745,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "d": {
@@ -754,7 +754,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.42"
       }
     },
     "dargs": {
@@ -763,7 +763,7 @@
       "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "dashdash": {
@@ -771,7 +771,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -787,8 +787,8 @@
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1",
-        "meow": "^3.3.0"
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0"
       }
     },
     "debug": {
@@ -811,8 +811,8 @@
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
+        "decamelize": "1.2.0",
+        "map-obj": "1.0.1"
       }
     },
     "deep-equal": {
@@ -838,13 +838,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.4.5"
       }
     },
     "delayed-stream": {
@@ -874,8 +874,8 @@
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "isarray": "^1.0.0"
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
       }
     },
     "dot-prop": {
@@ -884,7 +884,7 @@
       "integrity": "sha1-hI4o9/HVB0DGdHqzywdnBGK2+Jw=",
       "dev": true,
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "dtrace-provider": {
@@ -893,7 +893,7 @@
       "integrity": "sha1-CweNVReTfYcxAUUtkUZzdVe3XlE=",
       "optional": true,
       "requires": {
-        "nan": "^2.0.8"
+        "nan": "2.10.0"
       }
     },
     "ecc-jsbn": {
@@ -902,7 +902,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "error-ex": {
@@ -911,7 +911,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es5-ext": {
@@ -920,9 +920,9 @@
       "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
       "dev": true,
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-iterator": {
@@ -931,9 +931,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-map": {
@@ -942,12 +942,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-set": "~0.1.5",
-        "es6-symbol": "~3.1.1",
-        "event-emitter": "~0.3.5"
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
       }
     },
     "es6-promise": {
@@ -960,7 +960,7 @@
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
-        "es6-promise": "^4.0.3"
+        "es6-promise": "4.2.4"
       }
     },
     "es6-set": {
@@ -969,11 +969,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
-        "event-emitter": "~0.3.5"
+        "event-emitter": "0.3.5"
       }
     },
     "es6-symbol": {
@@ -982,8 +982,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.42"
       }
     },
     "es6-weak-map": {
@@ -992,10 +992,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "escape-regexp-component": {
@@ -1015,10 +1015,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "^0.1.3",
-        "es6-weak-map": "^2.0.1",
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
       }
     },
     "eslint": {
@@ -1027,39 +1027,39 @@
       "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "concat-stream": "^1.4.6",
-        "debug": "^2.1.1",
-        "doctrine": "^1.2.2",
-        "es6-map": "^0.1.3",
-        "escope": "^3.6.0",
-        "espree": "^3.1.6",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^1.1.1",
-        "glob": "^7.0.3",
-        "globals": "^9.2.0",
-        "ignore": "^3.1.2",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^0.12.0",
-        "is-my-json-valid": "^2.10.0",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.5.1",
-        "json-stable-stringify": "^1.0.0",
-        "levn": "^0.3.0",
-        "lodash": "^4.0.0",
-        "mkdirp": "^0.5.0",
-        "optionator": "^0.8.1",
-        "path-is-absolute": "^1.0.0",
-        "path-is-inside": "^1.0.1",
-        "pluralize": "^1.2.1",
-        "progress": "^1.1.8",
-        "require-uncached": "^1.0.2",
-        "shelljs": "^0.6.0",
-        "strip-json-comments": "~1.0.1",
-        "table": "^3.7.8",
-        "text-table": "~0.2.0",
-        "user-home": "^2.0.0"
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
+        "es6-map": "0.1.5",
+        "escope": "3.6.0",
+        "espree": "3.5.4",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "1.3.1",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.8",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.17.2",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.5.5",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "optionator": "0.8.2",
+        "path-is-absolute": "1.0.1",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.6.1",
+        "strip-json-comments": "1.0.4",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1077,12 +1077,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -1099,8 +1099,8 @@
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "^5.5.0",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "5.5.3",
+        "acorn-jsx": "3.0.1"
       }
     },
     "esprima": {
@@ -1115,7 +1115,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -1136,8 +1136,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.42"
       }
     },
     "eventemitter2": {
@@ -1196,8 +1196,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "file-entry-cache": {
@@ -1206,8 +1206,8 @@
       "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
       }
     },
     "find-up": {
@@ -1216,8 +1216,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "findup-sync": {
@@ -1226,7 +1226,7 @@
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
       "dev": true,
       "requires": {
-        "glob": "~5.0.0"
+        "glob": "5.0.15"
       },
       "dependencies": {
         "glob": {
@@ -1235,11 +1235,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -1250,10 +1250,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
       }
     },
     "foreachasync": {
@@ -1268,8 +1268,8 @@
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^4",
-        "signal-exit": "^3.0.0"
+        "cross-spawn": "4.0.2",
+        "signal-exit": "3.0.2"
       }
     },
     "forever-agent": {
@@ -1282,9 +1282,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.18"
       }
     },
     "formidable": {
@@ -1329,7 +1329,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "^1.0.0"
+        "is-property": "1.0.2"
       }
     },
     "get-pkg-repo": {
@@ -1338,10 +1338,10 @@
       "integrity": "sha1-fwTZaFZL+c0ukBgQV3+Ew38rA70=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "meow": "^3.3.0",
-        "normalize-package-data": "^2.3.0",
-        "through2": "^2.0.0"
+        "hosted-git-info": "2.6.0",
+        "meow": "3.7.0",
+        "normalize-package-data": "2.4.0",
+        "through2": "2.0.3"
       }
     },
     "get-stdin": {
@@ -1361,7 +1361,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -1377,11 +1377,11 @@
       "integrity": "sha1-v28G7UZoOgu0ve6EHNaZR8bt6ts=",
       "dev": true,
       "requires": {
-        "dargs": "^4.0.1",
-        "lodash.template": "^3.6.1",
-        "meow": "^3.1.0",
-        "split2": "^1.0.0",
-        "through2": "^2.0.0"
+        "dargs": "4.1.0",
+        "lodash.template": "3.6.2",
+        "meow": "3.7.0",
+        "split2": "1.1.1",
+        "through2": "2.0.3"
       }
     },
     "git-semver-tags": {
@@ -1390,8 +1390,8 @@
       "integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
       "dev": true,
       "requires": {
-        "meow": "^4.0.0",
-        "semver": "^5.5.0"
+        "meow": "4.0.1",
+        "semver": "5.5.0"
       },
       "dependencies": {
         "camelcase-keys": {
@@ -1400,9 +1400,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "find-up": {
@@ -1411,7 +1411,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "indent-string": {
@@ -1426,10 +1426,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "map-obj": {
@@ -1444,15 +1444,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
           }
         },
         "minimist": {
@@ -1467,8 +1467,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "path-type": {
@@ -1477,7 +1477,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -1492,9 +1492,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -1503,8 +1503,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "redent": {
@@ -1513,8 +1513,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "strip-bom": {
@@ -1542,11 +1542,11 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
       "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
       "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "globals": {
@@ -1561,12 +1561,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "glob": {
@@ -1575,12 +1575,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -1597,22 +1597,22 @@
       "integrity": "sha1-6HeHZOlEsY8yuw8QuQeEdcnftWs=",
       "dev": true,
       "requires": {
-        "coffee-script": "~1.10.0",
-        "dateformat": "~1.0.12",
-        "eventemitter2": "~0.4.13",
-        "exit": "~0.1.1",
-        "findup-sync": "~0.3.0",
-        "glob": "~7.0.0",
-        "grunt-cli": "~1.2.0",
-        "grunt-known-options": "~1.1.0",
-        "grunt-legacy-log": "~1.0.0",
-        "grunt-legacy-util": "~1.0.0",
-        "iconv-lite": "~0.4.13",
-        "js-yaml": "~3.5.2",
-        "minimatch": "~3.0.0",
-        "nopt": "~3.0.6",
-        "path-is-absolute": "~1.0.0",
-        "rimraf": "~2.2.8"
+        "coffee-script": "1.10.0",
+        "dateformat": "1.0.12",
+        "eventemitter2": "0.4.14",
+        "exit": "0.1.2",
+        "findup-sync": "0.3.0",
+        "glob": "7.0.6",
+        "grunt-cli": "1.2.0",
+        "grunt-known-options": "1.1.0",
+        "grunt-legacy-log": "1.0.2",
+        "grunt-legacy-util": "1.0.0",
+        "iconv-lite": "0.4.23",
+        "js-yaml": "3.5.5",
+        "minimatch": "3.0.4",
+        "nopt": "3.0.6",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.2.8"
       },
       "dependencies": {
         "glob": {
@@ -1621,12 +1621,12 @@
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.2",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "rimraf": {
@@ -1643,7 +1643,7 @@
       "integrity": "sha1-0//gzzzws44JYHt4U49CpTHq/lU=",
       "dev": true,
       "requires": {
-        "semver": "^5.1.0"
+        "semver": "5.5.0"
       }
     },
     "grunt-cli": {
@@ -1652,10 +1652,10 @@
       "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
       "dev": true,
       "requires": {
-        "findup-sync": "~0.3.0",
-        "grunt-known-options": "~1.1.0",
-        "nopt": "~3.0.6",
-        "resolve": "~1.1.0"
+        "findup-sync": "0.3.0",
+        "grunt-known-options": "1.1.0",
+        "nopt": "3.0.6",
+        "resolve": "1.1.7"
       }
     },
     "grunt-conventional-changelog": {
@@ -1664,11 +1664,11 @@
       "integrity": "sha1-JcBLL21WfBSBviC/F7gVyo/u6fQ=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.0",
-        "concat-stream": "^1.5.0",
-        "conventional-changelog": "^0.2.1",
-        "plur": "^2.0.0",
-        "q": "^1.4.1"
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.2",
+        "conventional-changelog": "0.2.1",
+        "plur": "2.1.2",
+        "q": "1.5.1"
       }
     },
     "grunt-copyright": {
@@ -1683,8 +1683,8 @@
       "integrity": "sha1-QOAe2Vx++J4PBdygHy3bM8JtEjg=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "eslint": "^2.0.0"
+        "chalk": "1.1.3",
+        "eslint": "2.13.1"
       }
     },
     "grunt-known-options": {
@@ -1699,10 +1699,10 @@
       "integrity": "sha512-WdedTJ/6zCXnI/coaouzqvkI19uwqbcPkdsXiDRKJyB5rOUlOxnCnTVbpeUdEckKVir2uHF3rDBYppj2p6N3+g==",
       "dev": true,
       "requires": {
-        "colors": "~1.1.2",
-        "grunt-legacy-log-utils": "~1.0.0",
-        "hooker": "~0.2.3",
-        "lodash": "~4.17.5"
+        "colors": "1.1.2",
+        "grunt-legacy-log-utils": "1.0.0",
+        "hooker": "0.2.3",
+        "lodash": "4.17.10"
       }
     },
     "grunt-legacy-log-utils": {
@@ -1711,8 +1711,8 @@
       "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
       "dev": true,
       "requires": {
-        "chalk": "~1.1.1",
-        "lodash": "~4.3.0"
+        "chalk": "1.1.3",
+        "lodash": "4.3.0"
       },
       "dependencies": {
         "lodash": {
@@ -1729,13 +1729,13 @@
       "integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
       "dev": true,
       "requires": {
-        "async": "~1.5.2",
-        "exit": "~0.1.1",
-        "getobject": "~0.1.0",
-        "hooker": "~0.2.3",
-        "lodash": "~4.3.0",
-        "underscore.string": "~3.2.3",
-        "which": "~1.2.1"
+        "async": "1.5.2",
+        "exit": "0.1.2",
+        "getobject": "0.1.0",
+        "hooker": "0.2.3",
+        "lodash": "4.3.0",
+        "underscore.string": "3.2.3",
+        "which": "1.2.14"
       },
       "dependencies": {
         "async": {
@@ -1758,7 +1758,7 @@
       "integrity": "sha1-bB0l+35yU36GfX1NNQb6oJTpejg=",
       "dev": true,
       "requires": {
-        "nsp": "^2.6.0"
+        "nsp": "2.8.1"
       }
     },
     "handle-thing": {
@@ -1772,9 +1772,9 @@
       "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
       "dev": true,
       "requires": {
-        "optimist": "^0.6.1",
-        "source-map": "^0.1.40",
-        "uglify-js": "~2.3"
+        "optimist": "0.6.1",
+        "source-map": "0.1.43",
+        "uglify-js": "2.3.6"
       }
     },
     "har-schema": {
@@ -1788,10 +1788,10 @@
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "commander": "^2.9.0",
-        "is-my-json-valid": "^2.12.4",
-        "pinkie-promise": "^2.0.0"
+        "chalk": "1.1.3",
+        "commander": "2.15.1",
+        "is-my-json-valid": "2.17.2",
+        "pinkie-promise": "2.0.1"
       }
     },
     "has-ansi": {
@@ -1800,7 +1800,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "hashring": {
@@ -1808,8 +1808,8 @@
       "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
       "integrity": "sha1-/aTv3oqiLNuX+x0qZeiEAeHBRM4=",
       "requires": {
-        "connection-parse": "0.0.x",
-        "simple-lru-cache": "0.0.x"
+        "connection-parse": "0.0.7",
+        "simple-lru-cache": "0.0.2"
       }
     },
     "hawk": {
@@ -1818,10 +1818,10 @@
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
       "requires": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x",
-        "sntp": "1.x.x"
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
       }
     },
     "hoek": {
@@ -1847,10 +1847,10 @@
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "requires": {
-        "inherits": "^2.0.1",
-        "obuf": "^1.0.0",
-        "readable-stream": "^2.0.1",
-        "wbuf": "^1.1.0"
+        "inherits": "2.0.3",
+        "obuf": "1.1.2",
+        "readable-stream": "2.0.6",
+        "wbuf": "1.7.3"
       }
     },
     "http-deceiver": {
@@ -1864,7 +1864,7 @@
       "integrity": "sha1-F5bPZ6ABrVzWhJ3KCZFIXwkIn+Y=",
       "requires": {
         "asn1": "0.1.11",
-        "assert-plus": "^0.1.5",
+        "assert-plus": "0.1.5",
         "ctype": "0.5.3"
       }
     },
@@ -1873,8 +1873,8 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "requires": {
-        "agent-base": "^4.1.0",
-        "debug": "^3.1.0"
+        "agent-base": "4.2.0",
+        "debug": "3.1.0"
       }
     },
     "iconv-lite": {
@@ -1883,7 +1883,7 @@
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ignore": {
@@ -1904,7 +1904,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "inflight": {
@@ -1912,8 +1912,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -1927,19 +1927,19 @@
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^1.1.0",
-        "ansi-regex": "^2.0.0",
-        "chalk": "^1.0.0",
-        "cli-cursor": "^1.0.1",
-        "cli-width": "^2.0.0",
-        "figures": "^1.3.5",
-        "lodash": "^4.3.0",
-        "readline2": "^1.0.1",
-        "run-async": "^0.1.0",
-        "rx-lite": "^3.1.2",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.0",
-        "through": "^2.3.6"
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.2.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.10",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
       }
     },
     "ip": {
@@ -1948,13 +1948,13 @@
       "integrity": "sha1-ErFilKOJJUhtYYoRA1BuTrT4spY="
     },
     "ip-reputation-js-client": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ip-reputation-js-client/-/ip-reputation-js-client-3.0.1.tgz",
-      "integrity": "sha512-JtcqPSVcvcchWYIl2u6pk1crB039VX4ncZEn6s/BYwJsc8IWQTpvlnVMS5mXh41uKUR7XUUGA+ZUx6uzh9oFzg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ip-reputation-js-client/-/ip-reputation-js-client-4.0.1.tgz",
+      "integrity": "sha512-R6aIpkpr4/AhxK2G5VwduxFcM2o7yka7KGVuUyV/5yQHIQoSD26vZ5zisaOsPyeEDJ2UuXQzxDvqLqYiFj3Lcg==",
       "requires": {
         "bluebird": "3.5.1",
-        "joi": "13",
-        "request": "2.85"
+        "joi": "13.3.0",
+        "request": "2.85.0"
       },
       "dependencies": {
         "bluebird": {
@@ -1982,7 +1982,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-finite": {
@@ -1991,7 +1991,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -2000,7 +2000,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-my-ip-valid": {
@@ -2015,11 +2015,11 @@
       "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "dev": true,
       "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
       }
     },
     "is-obj": {
@@ -2040,7 +2040,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -2049,7 +2049,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-obj": {
@@ -2082,7 +2082,7 @@
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
-        "text-extensions": "^1.0.0"
+        "text-extensions": "1.7.0"
       }
     },
     "is-typedarray": {
@@ -2106,7 +2106,7 @@
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
       "integrity": "sha512-zfRhJn9rFSGhzU5tGZqepRSAj3+g6oTOHxMGGriWNJZzyLPUK8H7VHpqKntegnW8KLyGA9zwuNaCoopl40LTpg==",
       "requires": {
-        "punycode": "2.x.x"
+        "punycode": "2.1.1"
       },
       "dependencies": {
         "punycode": {
@@ -2140,9 +2140,9 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-13.3.0.tgz",
       "integrity": "sha512-iF6jEYVfBIoYXztYymia1JfuoVbxBNuOcwdbsdoGin9/jjhBLhonKmfTQOvePss8r8v4tU4JOcNmYPHZzKEFag==",
       "requires": {
-        "hoek": "5.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
+        "hoek": "5.0.3",
+        "isemail": "3.1.2",
+        "topo": "3.0.0"
       },
       "dependencies": {
         "hoek": {
@@ -2158,8 +2158,8 @@
       "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.2",
-        "esprima": "^2.6.0"
+        "argparse": "1.0.10",
+        "esprima": "2.7.3"
       },
       "dependencies": {
         "esprima": {
@@ -2198,7 +2198,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -2269,8 +2269,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "load-grunt-tasks": {
@@ -2279,10 +2279,10 @@
       "integrity": "sha1-VuMQdRtYYXgmpiqa/M7Q5KAMhDA=",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.0",
-        "multimatch": "^2.0.0",
-        "pkg-up": "^1.0.0",
-        "resolve-pkg": "^0.1.0"
+        "arrify": "1.0.1",
+        "multimatch": "2.1.0",
+        "pkg-up": "1.0.0",
+        "resolve-pkg": "0.1.0"
       }
     },
     "load-json-file": {
@@ -2291,11 +2291,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       }
     },
     "locate-path": {
@@ -2304,8 +2304,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -2333,10 +2333,10 @@
       "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
       "dev": true,
       "requires": {
-        "lodash._baseisequal": "^3.0.0",
-        "lodash._bindcallback": "^3.0.0",
-        "lodash.isarray": "^3.0.0",
-        "lodash.pairs": "^3.0.0"
+        "lodash._baseisequal": "3.0.7",
+        "lodash._bindcallback": "3.0.1",
+        "lodash.isarray": "3.0.4",
+        "lodash.pairs": "3.0.1"
       }
     },
     "lodash._basecopy": {
@@ -2351,7 +2351,7 @@
       "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
       "dev": true,
       "requires": {
-        "lodash.keys": "^3.0.0"
+        "lodash.keys": "3.1.2"
       }
     },
     "lodash._baseisequal": {
@@ -2360,9 +2360,9 @@
       "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
       "dev": true,
       "requires": {
-        "lodash.isarray": "^3.0.0",
-        "lodash.istypedarray": "^3.0.0",
-        "lodash.keys": "^3.0.0"
+        "lodash.isarray": "3.0.4",
+        "lodash.istypedarray": "3.0.6",
+        "lodash.keys": "3.1.2"
       }
     },
     "lodash._basetostring": {
@@ -2418,7 +2418,7 @@
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "dev": true,
       "requires": {
-        "lodash._root": "^3.0.0"
+        "lodash._root": "3.0.1"
       }
     },
     "lodash.isarguments": {
@@ -2450,9 +2450,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "lodash.map": {
@@ -2461,11 +2461,11 @@
       "integrity": "sha1-tIOs0beGxce0ksSV97UmYim8AMI=",
       "dev": true,
       "requires": {
-        "lodash._arraymap": "^3.0.0",
-        "lodash._basecallback": "^3.0.0",
-        "lodash._baseeach": "^3.0.0",
-        "lodash.isarray": "^3.0.0",
-        "lodash.keys": "^3.0.0"
+        "lodash._arraymap": "3.0.0",
+        "lodash._basecallback": "3.3.1",
+        "lodash._baseeach": "3.0.4",
+        "lodash.isarray": "3.0.4",
+        "lodash.keys": "3.1.2"
       }
     },
     "lodash.merge": {
@@ -2479,7 +2479,7 @@
       "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
       "dev": true,
       "requires": {
-        "lodash.keys": "^3.0.0"
+        "lodash.keys": "3.1.2"
       }
     },
     "lodash.restparam": {
@@ -2494,15 +2494,15 @@
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash._basetostring": "^3.0.0",
-        "lodash._basevalues": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0",
-        "lodash.keys": "^3.0.0",
-        "lodash.restparam": "^3.0.0",
-        "lodash.templatesettings": "^3.0.0"
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
       }
     },
     "lodash.templatesettings": {
@@ -2511,8 +2511,8 @@
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
       }
     },
     "log-driver": {
@@ -2527,8 +2527,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lru-cache": {
@@ -2536,8 +2536,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "lsmod": {
@@ -2556,8 +2556,8 @@
       "resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.1.tgz",
       "integrity": "sha1-l1ZLW0eNmL02pJHTJQnfDF6gzwc=",
       "requires": {
-        "hashring": "3.2.x",
-        "jackpot": ">=0.0.6"
+        "hashring": "3.2.0",
+        "jackpot": "0.0.6"
       }
     },
     "meow": {
@@ -2566,16 +2566,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -2606,7 +2606,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.33.0"
       }
     },
     "minimalistic-assert": {
@@ -2619,7 +2619,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -2633,8 +2633,8 @@
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
+        "arrify": "1.0.1",
+        "is-plain-obj": "1.1.0"
       }
     },
     "mkdirp": {
@@ -2668,10 +2668,10 @@
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4"
       }
     },
     "mute-stream": {
@@ -2686,9 +2686,9 @@
       "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
       "optional": true,
       "requires": {
-        "mkdirp": "~0.5.1",
-        "ncp": "~2.0.0",
-        "rimraf": "~2.4.0"
+        "mkdirp": "0.5.1",
+        "ncp": "2.0.0",
+        "rimraf": "2.4.5"
       }
     },
     "nan": {
@@ -2713,15 +2713,15 @@
       "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-4.1.0.tgz",
       "integrity": "sha1-c3nJxB8/9XgfmNT436TTvlwtESk=",
       "requires": {
-        "@newrelic/koa": "^1.0.0",
-        "@newrelic/native-metrics": "^2.1.0",
-        "@tyriar/fibonacci-heap": "^2.0.7",
-        "async": "^2.1.4",
-        "concat-stream": "^1.5.0",
-        "https-proxy-agent": "^2.2.1",
-        "json-stringify-safe": "^5.0.0",
-        "readable-stream": "^2.1.4",
-        "semver": "^5.3.0"
+        "@newrelic/koa": "1.0.5",
+        "@newrelic/native-metrics": "2.4.0",
+        "@tyriar/fibonacci-heap": "2.0.7",
+        "async": "2.6.0",
+        "concat-stream": "1.6.2",
+        "https-proxy-agent": "2.2.1",
+        "json-stringify-safe": "5.0.1",
+        "readable-stream": "2.3.6",
+        "semver": "5.5.0"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -2734,13 +2734,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -2748,7 +2748,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -2765,7 +2765,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -2774,10 +2774,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.6.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "npmshrink": {
@@ -2792,17 +2792,17 @@
       "integrity": "sha512-jvjDg2Gsw4coD/iZ5eQddsDlkvnwMCNnpG05BproSnuG+Gr1bSQMwWMcQeYje+qdDl3XznmhblMPLpZLecTORQ==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "cli-table": "^0.3.1",
-        "cvss": "^1.0.0",
-        "https-proxy-agent": "^1.0.0",
-        "joi": "^6.9.1",
-        "nodesecurity-npm-utils": "^5.0.0",
-        "path-is-absolute": "^1.0.0",
-        "rc": "^1.1.2",
-        "semver": "^5.0.3",
-        "subcommand": "^2.0.3",
-        "wreck": "^6.3.0"
+        "chalk": "1.1.3",
+        "cli-table": "0.3.1",
+        "cvss": "1.0.2",
+        "https-proxy-agent": "1.0.0",
+        "joi": "6.10.1",
+        "nodesecurity-npm-utils": "5.0.0",
+        "path-is-absolute": "1.0.1",
+        "rc": "1.2.1",
+        "semver": "5.4.1",
+        "subcommand": "2.1.0",
+        "wreck": "6.3.0"
       },
       "dependencies": {
         "agent-base": {
@@ -2811,8 +2811,8 @@
           "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
           "dev": true,
           "requires": {
-            "extend": "~3.0.0",
-            "semver": "~5.0.1"
+            "extend": "3.0.1",
+            "semver": "5.0.3"
           },
           "dependencies": {
             "semver": {
@@ -2841,7 +2841,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "chalk": {
@@ -2850,11 +2850,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "cli-table": {
@@ -2917,7 +2917,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "hoek": {
@@ -2932,9 +2932,9 @@
           "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
           "dev": true,
           "requires": {
-            "agent-base": "2",
-            "debug": "2",
-            "extend": "3"
+            "agent-base": "2.1.1",
+            "debug": "2.6.9",
+            "extend": "3.0.1"
           }
         },
         "ini": {
@@ -2955,10 +2955,10 @@
           "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
           "dev": true,
           "requires": {
-            "hoek": "2.x.x",
-            "isemail": "1.x.x",
-            "moment": "2.x.x",
-            "topo": "1.x.x"
+            "hoek": "2.16.3",
+            "isemail": "1.2.0",
+            "moment": "2.18.1",
+            "topo": "1.1.0"
           }
         },
         "minimist": {
@@ -2997,10 +2997,10 @@
           "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true,
           "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           }
         },
         "semver": {
@@ -3015,7 +3015,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -3030,10 +3030,10 @@
           "integrity": "sha1-XkzspaN3njNlsVEeBfhmh3MC92A=",
           "dev": true,
           "requires": {
-            "cliclopts": "^1.1.0",
-            "debug": "^2.1.3",
-            "minimist": "^1.2.0",
-            "xtend": "^4.0.0"
+            "cliclopts": "1.1.1",
+            "debug": "2.6.9",
+            "minimist": "1.2.0",
+            "xtend": "4.0.1"
           }
         },
         "supports-color": {
@@ -3048,7 +3048,7 @@
           "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "wreck": {
@@ -3057,8 +3057,8 @@
           "integrity": "sha1-oTaXafB7u2LWo3gzanhx/Hc8dAs=",
           "dev": true,
           "requires": {
-            "boom": "2.x.x",
-            "hoek": "2.x.x"
+            "boom": "2.10.1",
+            "hoek": "2.16.3"
           }
         },
         "xtend": {
@@ -3081,27 +3081,27 @@
       "integrity": "sha1-L2AUYQpXBwAhxMBn6bnjMKI6xqc=",
       "dev": true,
       "requires": {
-        "append-transform": "^0.4.0",
-        "arrify": "^1.0.1",
-        "caching-transform": "^1.0.0",
-        "convert-source-map": "^1.1.2",
-        "default-require-extensions": "^1.0.0",
-        "find-cache-dir": "^0.1.1",
-        "find-up": "^1.1.2",
-        "foreground-child": "^1.5.1",
-        "glob": "^7.0.3",
-        "istanbul": "^0.4.3",
-        "md5-hex": "^1.2.0",
-        "micromatch": "^2.3.7",
-        "mkdirp": "^0.5.0",
-        "pkg-up": "^1.0.0",
-        "resolve-from": "^2.0.0",
-        "rimraf": "^2.5.0",
-        "signal-exit": "^3.0.0",
-        "source-map": "^0.5.3",
-        "spawn-wrap": "^1.2.2",
-        "test-exclude": "^1.1.0",
-        "yargs": "^4.7.0"
+        "append-transform": "0.4.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.2.0",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "1.1.2",
+        "foreground-child": "1.5.1",
+        "glob": "7.0.3",
+        "istanbul": "0.4.3",
+        "md5-hex": "1.3.0",
+        "micromatch": "2.3.8",
+        "mkdirp": "0.5.1",
+        "pkg-up": "1.0.0",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.5.2",
+        "signal-exit": "3.0.0",
+        "source-map": "0.5.6",
+        "spawn-wrap": "1.2.3",
+        "test-exclude": "1.1.0",
+        "yargs": "4.7.1"
       },
       "dependencies": {
         "append-transform": {
@@ -3110,7 +3110,7 @@
           "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
           "dev": true,
           "requires": {
-            "default-require-extensions": "^1.0.0"
+            "default-require-extensions": "1.0.0"
           }
         },
         "arrify": {
@@ -3125,9 +3125,9 @@
           "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
           "dev": true,
           "requires": {
-            "md5-hex": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "write-file-atomic": "^1.1.4"
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.1.4"
           },
           "dependencies": {
             "write-file-atomic": {
@@ -3136,9 +3136,9 @@
               "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
               "dev": true,
               "requires": {
-                "graceful-fs": "^4.1.2",
-                "imurmurhash": "^0.1.4",
-                "slide": "^1.1.5"
+                "graceful-fs": "4.1.4",
+                "imurmurhash": "0.1.4",
+                "slide": "1.1.6"
               },
               "dependencies": {
                 "graceful-fs": {
@@ -3175,7 +3175,7 @@
           "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
           "dev": true,
           "requires": {
-            "strip-bom": "^2.0.0"
+            "strip-bom": "2.0.0"
           },
           "dependencies": {
             "strip-bom": {
@@ -3184,7 +3184,7 @@
               "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
               "dev": true,
               "requires": {
-                "is-utf8": "^0.2.0"
+                "is-utf8": "0.2.1"
               },
               "dependencies": {
                 "is-utf8": {
@@ -3203,9 +3203,9 @@
           "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "dev": true,
           "requires": {
-            "commondir": "^1.0.1",
-            "mkdirp": "^0.5.1",
-            "pkg-dir": "^1.0.0"
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
           },
           "dependencies": {
             "commondir": {
@@ -3220,7 +3220,7 @@
               "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
               "dev": true,
               "requires": {
-                "find-up": "^1.0.0"
+                "find-up": "1.1.2"
               }
             }
           }
@@ -3231,8 +3231,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           },
           "dependencies": {
             "path-exists": {
@@ -3241,7 +3241,7 @@
               "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
               "dev": true,
               "requires": {
-                "pinkie-promise": "^2.0.0"
+                "pinkie-promise": "2.0.1"
               }
             },
             "pinkie-promise": {
@@ -3250,7 +3250,7 @@
               "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
               "dev": true,
               "requires": {
-                "pinkie": "^2.0.0"
+                "pinkie": "2.0.4"
               },
               "dependencies": {
                 "pinkie": {
@@ -3269,9 +3269,9 @@
           "integrity": "sha1-76NNl4DSV8dQsR4pbi4e3BT/+qo=",
           "dev": true,
           "requires": {
-            "cross-spawn-async": "^2.1.1",
-            "signal-exit": "^2.0.0",
-            "which": "^1.2.1"
+            "cross-spawn-async": "2.2.4",
+            "signal-exit": "2.1.2",
+            "which": "1.2.10"
           },
           "dependencies": {
             "cross-spawn-async": {
@@ -3280,8 +3280,8 @@
               "integrity": "sha1-yajY6aBlAsekYpbjOhoFS10vGBI=",
               "dev": true,
               "requires": {
-                "lru-cache": "^4.0.0",
-                "which": "^1.2.8"
+                "lru-cache": "4.0.1",
+                "which": "1.2.10"
               },
               "dependencies": {
                 "lru-cache": {
@@ -3290,8 +3290,8 @@
                   "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
                   "dev": true,
                   "requires": {
-                    "pseudomap": "^1.0.1",
-                    "yallist": "^2.0.0"
+                    "pseudomap": "1.0.2",
+                    "yallist": "2.0.0"
                   },
                   "dependencies": {
                     "pseudomap": {
@@ -3322,7 +3322,7 @@
               "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
               "dev": true,
               "requires": {
-                "isexe": "^1.1.1"
+                "isexe": "1.1.2"
               },
               "dependencies": {
                 "isexe": {
@@ -3341,11 +3341,11 @@
           "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.5",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.0",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.0"
           },
           "dependencies": {
             "inflight": {
@@ -3354,8 +3354,8 @@
               "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
               "dev": true,
               "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.3.3",
+                "wrappy": "1.0.2"
               },
               "dependencies": {
                 "wrappy": {
@@ -3378,7 +3378,7 @@
               "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
               "dev": true,
               "requires": {
-                "brace-expansion": "^1.0.0"
+                "brace-expansion": "1.1.4"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -3387,7 +3387,7 @@
                   "integrity": "sha1-RkogTHf0gsCFwqNsRWu/uvtnoSc=",
                   "dev": true,
                   "requires": {
-                    "balanced-match": "^0.4.1",
+                    "balanced-match": "0.4.1",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -3413,7 +3413,7 @@
               "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
               "dev": true,
               "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
               },
               "dependencies": {
                 "wrappy": {
@@ -3438,20 +3438,20 @@
           "integrity": "sha1-W3FO4K5JOsXvIEuZ84crzu9z1To=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.x",
-            "async": "1.x",
-            "escodegen": "1.8.x",
-            "esprima": "2.7.x",
-            "fileset": "0.2.x",
-            "handlebars": "^4.0.1",
-            "js-yaml": "3.x",
-            "mkdirp": "0.5.x",
-            "nopt": "3.x",
-            "once": "1.x",
-            "resolve": "1.1.x",
-            "supports-color": "^3.1.0",
-            "which": "^1.1.1",
-            "wordwrap": "^1.0.0"
+            "abbrev": "1.0.7",
+            "async": "1.5.2",
+            "escodegen": "1.8.0",
+            "esprima": "2.7.2",
+            "fileset": "0.2.1",
+            "handlebars": "4.0.5",
+            "js-yaml": "3.6.1",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "once": "1.3.3",
+            "resolve": "1.1.7",
+            "supports-color": "3.1.2",
+            "which": "1.2.10",
+            "wordwrap": "1.0.0"
           },
           "dependencies": {
             "abbrev": {
@@ -3472,11 +3472,11 @@
               "integrity": "sha1-skaq6CnOc9WeLFVyc1nt0cEwqBs=",
               "dev": true,
               "requires": {
-                "esprima": "^2.7.1",
-                "estraverse": "^1.9.1",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.2.0"
+                "esprima": "2.7.2",
+                "estraverse": "1.9.3",
+                "esutils": "2.0.2",
+                "optionator": "0.8.1",
+                "source-map": "0.2.0"
               },
               "dependencies": {
                 "estraverse": {
@@ -3497,12 +3497,12 @@
                   "integrity": "sha1-4xtJMs3V+4Yqiw0QvGPT7h7H14s=",
                   "dev": true,
                   "requires": {
-                    "deep-is": "~0.1.3",
-                    "fast-levenshtein": "^1.1.0",
-                    "levn": "~0.3.0",
-                    "prelude-ls": "~1.1.2",
-                    "type-check": "~0.3.2",
-                    "wordwrap": "~1.0.0"
+                    "deep-is": "0.1.3",
+                    "fast-levenshtein": "1.1.3",
+                    "levn": "0.3.0",
+                    "prelude-ls": "1.1.2",
+                    "type-check": "0.3.2",
+                    "wordwrap": "1.0.0"
                   },
                   "dependencies": {
                     "deep-is": {
@@ -3523,8 +3523,8 @@
                       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
                       "dev": true,
                       "requires": {
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2"
+                        "prelude-ls": "1.1.2",
+                        "type-check": "0.3.2"
                       }
                     },
                     "prelude-ls": {
@@ -3539,7 +3539,7 @@
                       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
                       "dev": true,
                       "requires": {
-                        "prelude-ls": "~1.1.2"
+                        "prelude-ls": "1.1.2"
                       }
                     }
                   }
@@ -3551,7 +3551,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "amdefine": ">=0.0.4"
+                    "amdefine": "1.0.0"
                   },
                   "dependencies": {
                     "amdefine": {
@@ -3577,8 +3577,8 @@
               "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
               "dev": true,
               "requires": {
-                "glob": "5.x",
-                "minimatch": "2.x"
+                "glob": "5.0.15",
+                "minimatch": "2.0.10"
               },
               "dependencies": {
                 "glob": {
@@ -3587,11 +3587,11 @@
                   "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                   "dev": true,
                   "requires": {
-                    "inflight": "^1.0.4",
-                    "inherits": "2",
-                    "minimatch": "2 || 3",
-                    "once": "^1.3.0",
-                    "path-is-absolute": "^1.0.0"
+                    "inflight": "1.0.5",
+                    "inherits": "2.0.1",
+                    "minimatch": "2.0.10",
+                    "once": "1.3.3",
+                    "path-is-absolute": "1.0.0"
                   },
                   "dependencies": {
                     "inflight": {
@@ -3600,8 +3600,8 @@
                       "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
                       "dev": true,
                       "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.3.3",
+                        "wrappy": "1.0.2"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -3632,7 +3632,7 @@
                   "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "^1.0.0"
+                    "brace-expansion": "1.1.4"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -3641,7 +3641,7 @@
                       "integrity": "sha1-RkogTHf0gsCFwqNsRWu/uvtnoSc=",
                       "dev": true,
                       "requires": {
-                        "balanced-match": "^0.4.1",
+                        "balanced-match": "0.4.1",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -3669,10 +3669,10 @@
               "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
               "dev": true,
               "requires": {
-                "async": "^1.4.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.4.4",
-                "uglify-js": "^2.6"
+                "async": "1.5.2",
+                "optimist": "0.6.1",
+                "source-map": "0.4.4",
+                "uglify-js": "2.6.2"
               },
               "dependencies": {
                 "optimist": {
@@ -3681,8 +3681,8 @@
                   "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
                   "dev": true,
                   "requires": {
-                    "minimist": "~0.0.1",
-                    "wordwrap": "~0.0.2"
+                    "minimist": "0.0.10",
+                    "wordwrap": "0.0.3"
                   },
                   "dependencies": {
                     "minimist": {
@@ -3705,7 +3705,7 @@
                   "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                   "dev": true,
                   "requires": {
-                    "amdefine": ">=0.0.4"
+                    "amdefine": "1.0.0"
                   },
                   "dependencies": {
                     "amdefine": {
@@ -3723,10 +3723,10 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "async": "~0.2.6",
-                    "source-map": "~0.5.1",
-                    "uglify-to-browserify": "~1.0.0",
-                    "yargs": "~3.10.0"
+                    "async": "0.2.10",
+                    "source-map": "0.5.6",
+                    "uglify-to-browserify": "1.0.2",
+                    "yargs": "3.10.0"
                   },
                   "dependencies": {
                     "async": {
@@ -3757,9 +3757,9 @@
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "camelcase": "^1.0.2",
-                        "cliui": "^2.1.0",
-                        "decamelize": "^1.0.0",
+                        "camelcase": "1.2.1",
+                        "cliui": "2.1.0",
+                        "decamelize": "1.2.0",
                         "window-size": "0.1.0"
                       },
                       "dependencies": {
@@ -3777,8 +3777,8 @@
                           "dev": true,
                           "optional": true,
                           "requires": {
-                            "center-align": "^0.1.1",
-                            "right-align": "^0.1.1",
+                            "center-align": "0.1.3",
+                            "right-align": "0.1.3",
                             "wordwrap": "0.0.2"
                           },
                           "dependencies": {
@@ -3789,8 +3789,8 @@
                               "dev": true,
                               "optional": true,
                               "requires": {
-                                "align-text": "^0.1.3",
-                                "lazy-cache": "^1.0.3"
+                                "align-text": "0.1.4",
+                                "lazy-cache": "1.0.4"
                               },
                               "dependencies": {
                                 "align-text": {
@@ -3800,9 +3800,9 @@
                                   "dev": true,
                                   "optional": true,
                                   "requires": {
-                                    "kind-of": "^3.0.2",
-                                    "longest": "^1.0.1",
-                                    "repeat-string": "^1.5.2"
+                                    "kind-of": "3.0.3",
+                                    "longest": "1.0.1",
+                                    "repeat-string": "1.5.4"
                                   },
                                   "dependencies": {
                                     "kind-of": {
@@ -3812,7 +3812,7 @@
                                       "dev": true,
                                       "optional": true,
                                       "requires": {
-                                        "is-buffer": "^1.0.2"
+                                        "is-buffer": "1.1.3"
                                       },
                                       "dependencies": {
                                         "is-buffer": {
@@ -3856,7 +3856,7 @@
                               "dev": true,
                               "optional": true,
                               "requires": {
-                                "align-text": "^0.1.1"
+                                "align-text": "0.1.4"
                               },
                               "dependencies": {
                                 "align-text": {
@@ -3866,9 +3866,9 @@
                                   "dev": true,
                                   "optional": true,
                                   "requires": {
-                                    "kind-of": "^3.0.2",
-                                    "longest": "^1.0.1",
-                                    "repeat-string": "^1.5.2"
+                                    "kind-of": "3.0.3",
+                                    "longest": "1.0.1",
+                                    "repeat-string": "1.5.4"
                                   },
                                   "dependencies": {
                                     "kind-of": {
@@ -3878,7 +3878,7 @@
                                       "dev": true,
                                       "optional": true,
                                       "requires": {
-                                        "is-buffer": "^1.0.2"
+                                        "is-buffer": "1.1.3"
                                       },
                                       "dependencies": {
                                         "is-buffer": {
@@ -3943,8 +3943,8 @@
               "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
               "dev": true,
               "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^2.6.0"
+                "argparse": "1.0.7",
+                "esprima": "2.7.2"
               },
               "dependencies": {
                 "argparse": {
@@ -3953,7 +3953,7 @@
                   "integrity": "sha1-wolQZIBVeBDxSovGLXoG9j7X+VE=",
                   "dev": true,
                   "requires": {
-                    "sprintf-js": "~1.0.2"
+                    "sprintf-js": "1.0.3"
                   },
                   "dependencies": {
                     "sprintf-js": {
@@ -3972,7 +3972,7 @@
               "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
               "dev": true,
               "requires": {
-                "abbrev": "1"
+                "abbrev": "1.0.7"
               }
             },
             "once": {
@@ -3981,7 +3981,7 @@
               "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
               "dev": true,
               "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
               },
               "dependencies": {
                 "wrappy": {
@@ -4004,7 +4004,7 @@
               "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
               "dev": true,
               "requires": {
-                "has-flag": "^1.0.0"
+                "has-flag": "1.0.0"
               },
               "dependencies": {
                 "has-flag": {
@@ -4021,7 +4021,7 @@
               "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
               "dev": true,
               "requires": {
-                "isexe": "^1.1.1"
+                "isexe": "1.1.2"
               },
               "dependencies": {
                 "isexe": {
@@ -4046,7 +4046,7 @@
           "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
-            "md5-o-matic": "^0.1.1"
+            "md5-o-matic": "0.1.1"
           },
           "dependencies": {
             "md5-o-matic": {
@@ -4063,19 +4063,19 @@
           "integrity": "sha1-lPv4837Z7eyga/HI97dD+19vWFQ=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.0",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.0.3",
+            "normalize-path": "2.0.1",
+            "object.omit": "2.0.0",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.3"
           },
           "dependencies": {
             "arr-diff": {
@@ -4084,7 +4084,7 @@
               "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
               "dev": true,
               "requires": {
-                "arr-flatten": "^1.0.1"
+                "arr-flatten": "1.0.1"
               },
               "dependencies": {
                 "arr-flatten": {
@@ -4107,9 +4107,9 @@
               "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
               "dev": true,
               "requires": {
-                "expand-range": "^1.8.1",
-                "preserve": "^0.2.0",
-                "repeat-element": "^1.1.2"
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
               },
               "dependencies": {
                 "expand-range": {
@@ -4118,7 +4118,7 @@
                   "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
                   "dev": true,
                   "requires": {
-                    "fill-range": "^2.1.0"
+                    "fill-range": "2.2.3"
                   },
                   "dependencies": {
                     "fill-range": {
@@ -4127,11 +4127,11 @@
                       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
                       "dev": true,
                       "requires": {
-                        "is-number": "^2.1.0",
-                        "isobject": "^2.0.0",
-                        "randomatic": "^1.1.3",
-                        "repeat-element": "^1.1.2",
-                        "repeat-string": "^1.5.2"
+                        "is-number": "2.1.0",
+                        "isobject": "2.1.0",
+                        "randomatic": "1.1.5",
+                        "repeat-element": "1.1.2",
+                        "repeat-string": "1.5.4"
                       },
                       "dependencies": {
                         "is-number": {
@@ -4140,7 +4140,7 @@
                           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
                           "dev": true,
                           "requires": {
-                            "kind-of": "^3.0.2"
+                            "kind-of": "3.0.3"
                           }
                         },
                         "isobject": {
@@ -4166,8 +4166,8 @@
                           "integrity": "sha1-Xp718tVzxnvSuBJK6QtRVuRXhAs=",
                           "dev": true,
                           "requires": {
-                            "is-number": "^2.0.2",
-                            "kind-of": "^3.0.2"
+                            "is-number": "2.1.0",
+                            "kind-of": "3.0.3"
                           }
                         },
                         "repeat-string": {
@@ -4200,7 +4200,7 @@
               "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
               "dev": true,
               "requires": {
-                "is-posix-bracket": "^0.1.0"
+                "is-posix-bracket": "0.1.1"
               },
               "dependencies": {
                 "is-posix-bracket": {
@@ -4217,7 +4217,7 @@
               "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
               "dev": true,
               "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "1.0.0"
               }
             },
             "filename-regex": {
@@ -4238,7 +4238,7 @@
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "1.0.0"
               }
             },
             "kind-of": {
@@ -4247,7 +4247,7 @@
               "integrity": "sha1-xhYIdH2BWwNiVW2zJ2Nip6OK3tM=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.0.2"
+                "is-buffer": "1.1.3"
               },
               "dependencies": {
                 "is-buffer": {
@@ -4270,8 +4270,8 @@
               "integrity": "sha1-hoWXMz1U5gZilAu0WGBd1q4S/pQ=",
               "dev": true,
               "requires": {
-                "for-own": "^0.1.3",
-                "is-extendable": "^0.1.1"
+                "for-own": "0.1.4",
+                "is-extendable": "0.1.1"
               },
               "dependencies": {
                 "for-own": {
@@ -4280,7 +4280,7 @@
                   "integrity": "sha1-AUm0GjkIjHUV9R6+HBOG1F+TUHI=",
                   "dev": true,
                   "requires": {
-                    "for-in": "^0.1.5"
+                    "for-in": "0.1.5"
                   },
                   "dependencies": {
                     "for-in": {
@@ -4305,10 +4305,10 @@
               "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
               "dev": true,
               "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.2",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
               },
               "dependencies": {
                 "glob-base": {
@@ -4317,8 +4317,8 @@
                   "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
                   "dev": true,
                   "requires": {
-                    "glob-parent": "^2.0.0",
-                    "is-glob": "^2.0.0"
+                    "glob-parent": "2.0.0",
+                    "is-glob": "2.0.1"
                   },
                   "dependencies": {
                     "glob-parent": {
@@ -4327,7 +4327,7 @@
                       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                       "dev": true,
                       "requires": {
-                        "is-glob": "^2.0.0"
+                        "is-glob": "2.0.1"
                       }
                     }
                   }
@@ -4346,8 +4346,8 @@
               "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
               "dev": true,
               "requires": {
-                "is-equal-shallow": "^0.1.3",
-                "is-primitive": "^2.0.0"
+                "is-equal-shallow": "0.1.3",
+                "is-primitive": "2.0.0"
               },
               "dependencies": {
                 "is-equal-shallow": {
@@ -4356,7 +4356,7 @@
                   "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
                   "dev": true,
                   "requires": {
-                    "is-primitive": "^2.0.0"
+                    "is-primitive": "2.0.0"
                   }
                 },
                 "is-primitive": {
@@ -4392,7 +4392,7 @@
           "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0"
+            "find-up": "1.1.2"
           }
         },
         "resolve-from": {
@@ -4407,7 +4407,7 @@
           "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY=",
           "dev": true,
           "requires": {
-            "glob": "^7.0.0"
+            "glob": "7.0.3"
           }
         },
         "signal-exit": {
@@ -4428,12 +4428,12 @@
           "integrity": "sha1-3300R/tKAZYZpB9o7mQqcY5gYuk=",
           "dev": true,
           "requires": {
-            "foreground-child": "^1.3.3",
-            "mkdirp": "^0.5.0",
-            "os-homedir": "^1.0.1",
-            "rimraf": "^2.3.3",
-            "signal-exit": "^2.0.0",
-            "which": "^1.2.4"
+            "foreground-child": "1.5.1",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.1",
+            "rimraf": "2.5.2",
+            "signal-exit": "2.1.2",
+            "which": "1.2.10"
           },
           "dependencies": {
             "os-homedir": {
@@ -4454,7 +4454,7 @@
               "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
               "dev": true,
               "requires": {
-                "isexe": "^1.1.1"
+                "isexe": "1.1.2"
               },
               "dependencies": {
                 "isexe": {
@@ -4473,11 +4473,11 @@
           "integrity": "sha1-9d3XGJJ7Ev0C8nCgqpOc627qQVE=",
           "dev": true,
           "requires": {
-            "arrify": "^1.0.1",
-            "lodash.assign": "^4.0.9",
-            "micromatch": "^2.3.8",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1"
+            "arrify": "1.0.1",
+            "lodash.assign": "4.0.9",
+            "micromatch": "2.3.8",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
           },
           "dependencies": {
             "lodash.assign": {
@@ -4486,8 +4486,8 @@
               "integrity": "sha1-Cgcx2TWQ3dm6RYn61lqvbuCSF+M=",
               "dev": true,
               "requires": {
-                "lodash.keys": "^4.0.0",
-                "lodash.rest": "^4.0.0"
+                "lodash.keys": "4.0.7",
+                "lodash.rest": "4.0.3"
               },
               "dependencies": {
                 "lodash.keys": {
@@ -4510,8 +4510,8 @@
               "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
               "dev": true,
               "requires": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
               },
               "dependencies": {
                 "read-pkg": {
@@ -4520,9 +4520,9 @@
                   "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                   "dev": true,
                   "requires": {
-                    "load-json-file": "^1.0.0",
-                    "normalize-package-data": "^2.3.2",
-                    "path-type": "^1.0.0"
+                    "load-json-file": "1.1.0",
+                    "normalize-package-data": "2.3.5",
+                    "path-type": "1.1.0"
                   },
                   "dependencies": {
                     "load-json-file": {
@@ -4531,11 +4531,11 @@
                       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                       "dev": true,
                       "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0",
-                        "strip-bom": "^2.0.0"
+                        "graceful-fs": "4.1.4",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
                       },
                       "dependencies": {
                         "graceful-fs": {
@@ -4550,7 +4550,7 @@
                           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                           "dev": true,
                           "requires": {
-                            "error-ex": "^1.2.0"
+                            "error-ex": "1.3.0"
                           },
                           "dependencies": {
                             "error-ex": {
@@ -4559,7 +4559,7 @@
                               "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
                               "dev": true,
                               "requires": {
-                                "is-arrayish": "^0.2.1"
+                                "is-arrayish": "0.2.1"
                               },
                               "dependencies": {
                                 "is-arrayish": {
@@ -4584,7 +4584,7 @@
                           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                           "dev": true,
                           "requires": {
-                            "pinkie": "^2.0.0"
+                            "pinkie": "2.0.4"
                           },
                           "dependencies": {
                             "pinkie": {
@@ -4601,7 +4601,7 @@
                           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                           "dev": true,
                           "requires": {
-                            "is-utf8": "^0.2.0"
+                            "is-utf8": "0.2.1"
                           },
                           "dependencies": {
                             "is-utf8": {
@@ -4620,10 +4620,10 @@
                       "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
                       "dev": true,
                       "requires": {
-                        "hosted-git-info": "^2.1.4",
-                        "is-builtin-module": "^1.0.0",
-                        "semver": "2 || 3 || 4 || 5",
-                        "validate-npm-package-license": "^3.0.1"
+                        "hosted-git-info": "2.1.5",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.1.0",
+                        "validate-npm-package-license": "3.0.1"
                       },
                       "dependencies": {
                         "hosted-git-info": {
@@ -4638,7 +4638,7 @@
                           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                           "dev": true,
                           "requires": {
-                            "builtin-modules": "^1.0.0"
+                            "builtin-modules": "1.1.1"
                           },
                           "dependencies": {
                             "builtin-modules": {
@@ -4661,8 +4661,8 @@
                           "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
                           "dev": true,
                           "requires": {
-                            "spdx-correct": "~1.0.0",
-                            "spdx-expression-parse": "~1.0.0"
+                            "spdx-correct": "1.0.2",
+                            "spdx-expression-parse": "1.0.2"
                           },
                           "dependencies": {
                             "spdx-correct": {
@@ -4671,7 +4671,7 @@
                               "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                               "dev": true,
                               "requires": {
-                                "spdx-license-ids": "^1.0.2"
+                                "spdx-license-ids": "1.2.1"
                               },
                               "dependencies": {
                                 "spdx-license-ids": {
@@ -4688,8 +4688,8 @@
                               "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
                               "dev": true,
                               "requires": {
-                                "spdx-exceptions": "^1.0.4",
-                                "spdx-license-ids": "^1.0.0"
+                                "spdx-exceptions": "1.0.4",
+                                "spdx-license-ids": "1.2.1"
                               },
                               "dependencies": {
                                 "spdx-exceptions": {
@@ -4716,9 +4716,9 @@
                       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                       "dev": true,
                       "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "graceful-fs": "4.1.4",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
                       },
                       "dependencies": {
                         "graceful-fs": {
@@ -4739,7 +4739,7 @@
                           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                           "dev": true,
                           "requires": {
-                            "pinkie": "^2.0.0"
+                            "pinkie": "2.0.4"
                           },
                           "dependencies": {
                             "pinkie": {
@@ -4770,19 +4770,19 @@
           "integrity": "sha1-5gQyZYozh/8mnAKOrN5KUS5Djf8=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "lodash.assign": "^4.0.3",
-            "os-locale": "^1.4.0",
-            "pkg-conf": "^1.1.2",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^1.0.0",
-            "string-width": "^1.0.1",
-            "window-size": "^0.2.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^2.4.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "lodash.assign": "4.0.9",
+            "os-locale": "1.4.0",
+            "pkg-conf": "1.1.3",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "1.0.0",
+            "string-width": "1.0.1",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.0"
           },
           "dependencies": {
             "camelcase": {
@@ -4797,9 +4797,9 @@
               "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
               "dev": true,
               "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "1.0.1",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.0.0"
               },
               "dependencies": {
                 "strip-ansi": {
@@ -4808,7 +4808,7 @@
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
-                    "ansi-regex": "^2.0.0"
+                    "ansi-regex": "2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -4825,7 +4825,7 @@
                   "integrity": "sha1-fTD4+HP5pbvDpk2ryNF34HGuQm8=",
                   "dev": true,
                   "requires": {
-                    "string-width": "^1.0.1"
+                    "string-width": "1.0.1"
                   }
                 }
               }
@@ -4842,8 +4842,8 @@
               "integrity": "sha1-Cgcx2TWQ3dm6RYn61lqvbuCSF+M=",
               "dev": true,
               "requires": {
-                "lodash.keys": "^4.0.0",
-                "lodash.rest": "^4.0.0"
+                "lodash.keys": "4.0.7",
+                "lodash.rest": "4.0.3"
               },
               "dependencies": {
                 "lodash.keys": {
@@ -4866,7 +4866,7 @@
               "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
               "dev": true,
               "requires": {
-                "lcid": "^1.0.0"
+                "lcid": "1.0.0"
               },
               "dependencies": {
                 "lcid": {
@@ -4875,7 +4875,7 @@
                   "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                   "dev": true,
                   "requires": {
-                    "invert-kv": "^1.0.0"
+                    "invert-kv": "1.0.0"
                   },
                   "dependencies": {
                     "invert-kv": {
@@ -4894,10 +4894,10 @@
               "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
               "dev": true,
               "requires": {
-                "find-up": "^1.0.0",
-                "load-json-file": "^1.1.0",
-                "object-assign": "^4.0.1",
-                "symbol": "^0.2.1"
+                "find-up": "1.1.2",
+                "load-json-file": "1.1.0",
+                "object-assign": "4.1.0",
+                "symbol": "0.2.3"
               },
               "dependencies": {
                 "load-json-file": {
@@ -4906,11 +4906,11 @@
                   "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "^4.1.2",
-                    "parse-json": "^2.2.0",
-                    "pify": "^2.0.0",
-                    "pinkie-promise": "^2.0.0",
-                    "strip-bom": "^2.0.0"
+                    "graceful-fs": "4.1.4",
+                    "parse-json": "2.2.0",
+                    "pify": "2.3.0",
+                    "pinkie-promise": "2.0.1",
+                    "strip-bom": "2.0.0"
                   },
                   "dependencies": {
                     "graceful-fs": {
@@ -4925,7 +4925,7 @@
                       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                       "dev": true,
                       "requires": {
-                        "error-ex": "^1.2.0"
+                        "error-ex": "1.3.0"
                       },
                       "dependencies": {
                         "error-ex": {
@@ -4934,7 +4934,7 @@
                           "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
                           "dev": true,
                           "requires": {
-                            "is-arrayish": "^0.2.1"
+                            "is-arrayish": "0.2.1"
                           },
                           "dependencies": {
                             "is-arrayish": {
@@ -4959,7 +4959,7 @@
                       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                       "dev": true,
                       "requires": {
-                        "pinkie": "^2.0.0"
+                        "pinkie": "2.0.4"
                       },
                       "dependencies": {
                         "pinkie": {
@@ -4976,7 +4976,7 @@
                       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                       "dev": true,
                       "requires": {
-                        "is-utf8": "^0.2.0"
+                        "is-utf8": "0.2.1"
                       },
                       "dependencies": {
                         "is-utf8": {
@@ -5009,8 +5009,8 @@
               "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
               "dev": true,
               "requires": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
               },
               "dependencies": {
                 "read-pkg": {
@@ -5019,9 +5019,9 @@
                   "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                   "dev": true,
                   "requires": {
-                    "load-json-file": "^1.0.0",
-                    "normalize-package-data": "^2.3.2",
-                    "path-type": "^1.0.0"
+                    "load-json-file": "1.1.0",
+                    "normalize-package-data": "2.3.5",
+                    "path-type": "1.1.0"
                   },
                   "dependencies": {
                     "load-json-file": {
@@ -5030,11 +5030,11 @@
                       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                       "dev": true,
                       "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0",
-                        "strip-bom": "^2.0.0"
+                        "graceful-fs": "4.1.4",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
                       },
                       "dependencies": {
                         "graceful-fs": {
@@ -5049,7 +5049,7 @@
                           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                           "dev": true,
                           "requires": {
-                            "error-ex": "^1.2.0"
+                            "error-ex": "1.3.0"
                           },
                           "dependencies": {
                             "error-ex": {
@@ -5058,7 +5058,7 @@
                               "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
                               "dev": true,
                               "requires": {
-                                "is-arrayish": "^0.2.1"
+                                "is-arrayish": "0.2.1"
                               },
                               "dependencies": {
                                 "is-arrayish": {
@@ -5083,7 +5083,7 @@
                           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                           "dev": true,
                           "requires": {
-                            "pinkie": "^2.0.0"
+                            "pinkie": "2.0.4"
                           },
                           "dependencies": {
                             "pinkie": {
@@ -5100,7 +5100,7 @@
                           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                           "dev": true,
                           "requires": {
-                            "is-utf8": "^0.2.0"
+                            "is-utf8": "0.2.1"
                           },
                           "dependencies": {
                             "is-utf8": {
@@ -5119,10 +5119,10 @@
                       "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
                       "dev": true,
                       "requires": {
-                        "hosted-git-info": "^2.1.4",
-                        "is-builtin-module": "^1.0.0",
-                        "semver": "2 || 3 || 4 || 5",
-                        "validate-npm-package-license": "^3.0.1"
+                        "hosted-git-info": "2.1.5",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.1.0",
+                        "validate-npm-package-license": "3.0.1"
                       },
                       "dependencies": {
                         "hosted-git-info": {
@@ -5137,7 +5137,7 @@
                           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                           "dev": true,
                           "requires": {
-                            "builtin-modules": "^1.0.0"
+                            "builtin-modules": "1.1.1"
                           },
                           "dependencies": {
                             "builtin-modules": {
@@ -5160,8 +5160,8 @@
                           "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
                           "dev": true,
                           "requires": {
-                            "spdx-correct": "~1.0.0",
-                            "spdx-expression-parse": "~1.0.0"
+                            "spdx-correct": "1.0.2",
+                            "spdx-expression-parse": "1.0.2"
                           },
                           "dependencies": {
                             "spdx-correct": {
@@ -5170,7 +5170,7 @@
                               "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                               "dev": true,
                               "requires": {
-                                "spdx-license-ids": "^1.0.2"
+                                "spdx-license-ids": "1.2.1"
                               },
                               "dependencies": {
                                 "spdx-license-ids": {
@@ -5187,8 +5187,8 @@
                               "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
                               "dev": true,
                               "requires": {
-                                "spdx-exceptions": "^1.0.4",
-                                "spdx-license-ids": "^1.0.0"
+                                "spdx-exceptions": "1.0.4",
+                                "spdx-license-ids": "1.2.1"
                               },
                               "dependencies": {
                                 "spdx-exceptions": {
@@ -5215,9 +5215,9 @@
                       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                       "dev": true,
                       "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "graceful-fs": "4.1.4",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
                       },
                       "dependencies": {
                         "graceful-fs": {
@@ -5238,7 +5238,7 @@
                           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                           "dev": true,
                           "requires": {
-                            "pinkie": "^2.0.0"
+                            "pinkie": "2.0.4"
                           },
                           "dependencies": {
                             "pinkie": {
@@ -5273,9 +5273,9 @@
               "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo=",
               "dev": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.0.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               },
               "dependencies": {
                 "code-point-at": {
@@ -5284,7 +5284,7 @@
                   "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
                   "dev": true,
                   "requires": {
-                    "number-is-nan": "^1.0.0"
+                    "number-is-nan": "1.0.0"
                   },
                   "dependencies": {
                     "number-is-nan": {
@@ -5301,7 +5301,7 @@
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
                   "requires": {
-                    "number-is-nan": "^1.0.0"
+                    "number-is-nan": "1.0.0"
                   },
                   "dependencies": {
                     "number-is-nan": {
@@ -5318,7 +5318,7 @@
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
-                    "ansi-regex": "^2.0.0"
+                    "ansi-regex": "2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -5349,8 +5349,8 @@
               "integrity": "sha1-HzZ9ycbPpWYLaXEjDzsnf8Xjrco=",
               "dev": true,
               "requires": {
-                "camelcase": "^2.1.1",
-                "lodash.assign": "^4.0.6"
+                "camelcase": "2.1.1",
+                "lodash.assign": "4.0.9"
               },
               "dependencies": {
                 "camelcase": {
@@ -5386,7 +5386,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -5413,8 +5413,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
       }
     },
     "optionator": {
@@ -5423,12 +5423,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -5457,7 +5457,7 @@
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -5466,7 +5466,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.2.0"
       }
     },
     "p-try": {
@@ -5481,7 +5481,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.1"
       }
     },
     "path-exists": {
@@ -5490,7 +5490,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^2.0.0"
+        "pinkie-promise": "2.0.1"
       }
     },
     "path-is-absolute": {
@@ -5510,9 +5510,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "performance-now": {
@@ -5538,7 +5538,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-up": {
@@ -5547,7 +5547,7 @@
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0"
+        "find-up": "1.1.2"
       }
     },
     "plur": {
@@ -5556,7 +5556,7 @@
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "dev": true,
       "requires": {
-        "irregular-plurals": "^1.0.0"
+        "irregular-plurals": "1.4.0"
       }
     },
     "pluralize": {
@@ -5632,9 +5632,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
@@ -5643,8 +5643,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       }
     },
     "readable-stream": {
@@ -5652,12 +5652,12 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
       "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "string_decoder": "0.10.31",
+        "util-deprecate": "1.0.2"
       }
     },
     "readline2": {
@@ -5666,8 +5666,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -5677,8 +5677,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       }
     },
     "redeyed": {
@@ -5687,7 +5687,7 @@
       "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
       "optional": true,
       "requires": {
-        "esprima": "~3.0.0"
+        "esprima": "3.0.0"
       }
     },
     "repeating": {
@@ -5696,7 +5696,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "request": {
@@ -5704,28 +5704,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "hawk": "~6.0.2",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
       },
       "dependencies": {
         "ajv": {
@@ -5733,10 +5733,10 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "assert-plus": {
@@ -5754,7 +5754,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "caseless": {
@@ -5767,7 +5767,7 @@
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
           "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
           "requires": {
-            "boom": "5.x.x"
+            "boom": "5.2.0"
           },
           "dependencies": {
             "boom": {
@@ -5775,7 +5775,7 @@
               "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
               "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
               "requires": {
-                "hoek": "4.x.x"
+                "hoek": "4.2.1"
               }
             }
           }
@@ -5785,8 +5785,8 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "requires": {
-            "ajv": "^5.1.0",
-            "har-schema": "^2.0.0"
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
           }
         },
         "hawk": {
@@ -5794,10 +5794,10 @@
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
           "requires": {
-            "boom": "4.x.x",
-            "cryptiles": "3.x.x",
-            "hoek": "4.x.x",
-            "sntp": "2.x.x"
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.1",
+            "sntp": "2.1.0"
           }
         },
         "hoek": {
@@ -5810,9 +5810,9 @@
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.1"
           }
         },
         "qs": {
@@ -5825,7 +5825,7 @@
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
           "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "tunnel-agent": {
@@ -5833,7 +5833,7 @@
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.1.2"
           }
         },
         "uuid": {
@@ -5849,8 +5849,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       }
     },
     "resolve": {
@@ -5871,7 +5871,7 @@
       "integrity": "sha1-AsyZNBDik2livZcWahsHfalyVTE=",
       "dev": true,
       "requires": {
-        "resolve-from": "^2.0.0"
+        "resolve-from": "2.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -5887,26 +5887,26 @@
       "resolved": "https://registry.npmjs.org/restify/-/restify-4.1.1.tgz",
       "integrity": "sha1-fp93HyuwgaD8yZHMPLTwlO2WX9s=",
       "requires": {
-        "assert-plus": "^0.1.5",
-        "backoff": "^2.4.0",
-        "bunyan": "^1.4.0",
-        "csv": "^0.4.0",
-        "dtrace-provider": "^0.6.0",
-        "escape-regexp-component": "^1.0.2",
-        "formidable": "^1.0.14",
-        "http-signature": "^0.11.0",
-        "keep-alive-agent": "^0.0.1",
-        "lru-cache": "^4.0.1",
-        "mime": "^1.2.11",
-        "negotiator": "^0.6.1",
-        "node-uuid": "^1.4.1",
-        "once": "^1.3.0",
-        "qs": "^3.1.0",
-        "semver": "^4.3.3",
-        "spdy": "^3.3.3",
-        "tunnel-agent": "^0.4.0",
+        "assert-plus": "0.1.5",
+        "backoff": "2.5.0",
+        "bunyan": "1.8.0",
+        "csv": "0.4.6",
+        "dtrace-provider": "0.6.0",
+        "escape-regexp-component": "1.0.2",
+        "formidable": "1.2.1",
+        "http-signature": "0.11.0",
+        "keep-alive-agent": "0.0.1",
+        "lru-cache": "4.1.3",
+        "mime": "1.6.0",
+        "negotiator": "0.6.1",
+        "node-uuid": "1.4.8",
+        "once": "1.4.0",
+        "qs": "3.1.0",
+        "semver": "4.3.6",
+        "spdy": "3.4.7",
+        "tunnel-agent": "0.4.3",
         "vasync": "1.6.3",
-        "verror": "^1.4.0"
+        "verror": "1.10.0"
       },
       "dependencies": {
         "node-uuid": {
@@ -5926,7 +5926,7 @@
       "resolved": "https://registry.npmjs.org/restify-safe-json-formatter/-/restify-safe-json-formatter-0.2.0.tgz",
       "integrity": "sha1-RDyvOKEECle2TSfD9IDLSnNJi1Q=",
       "requires": {
-        "restify": "^4.3.0"
+        "restify": "4.3.3"
       },
       "dependencies": {
         "dtrace-provider": {
@@ -5935,7 +5935,7 @@
           "integrity": "sha1-QooiOv4DQl0s1tY0f99AxmkDVj0=",
           "optional": true,
           "requires": {
-            "nan": "^2.3.3"
+            "nan": "2.10.0"
           }
         },
         "qs": {
@@ -5948,26 +5948,26 @@
           "resolved": "https://registry.npmjs.org/restify/-/restify-4.3.3.tgz",
           "integrity": "sha512-PKYab7wZWd/wenNacGek/nkAxNNJiGF2dtOBHhczNFWn9ZNnMFOaGEDwHiHWzmNN6eDJqYQ7CtvScOcNEH5tsA==",
           "requires": {
-            "assert-plus": "^0.1.5",
-            "backoff": "^2.4.0",
-            "bunyan": "^1.4.0",
-            "csv": "^0.4.0",
-            "dtrace-provider": "^0.8.2",
-            "escape-regexp-component": "^1.0.2",
-            "formidable": "^1.0.14",
-            "http-signature": "^0.11.0",
-            "keep-alive-agent": "^0.0.1",
-            "lru-cache": "^4.0.1",
-            "mime": "^1.2.11",
-            "negotiator": "^0.6.1",
-            "once": "^1.3.0",
-            "qs": "^6.2.1",
-            "semver": "^4.3.3",
-            "spdy": "^3.3.3",
-            "tunnel-agent": "^0.4.0",
-            "uuid": "^3.0.1",
+            "assert-plus": "0.1.5",
+            "backoff": "2.5.0",
+            "bunyan": "1.8.0",
+            "csv": "0.4.6",
+            "dtrace-provider": "0.8.6",
+            "escape-regexp-component": "1.0.2",
+            "formidable": "1.2.1",
+            "http-signature": "0.11.0",
+            "keep-alive-agent": "0.0.1",
+            "lru-cache": "4.1.3",
+            "mime": "1.6.0",
+            "negotiator": "0.6.1",
+            "once": "1.4.0",
+            "qs": "6.5.2",
+            "semver": "4.3.6",
+            "spdy": "3.4.7",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.2.1",
             "vasync": "1.6.3",
-            "verror": "^1.4.0"
+            "verror": "1.10.0"
           }
         },
         "semver": {
@@ -5988,8 +5988,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
       }
     },
     "retry": {
@@ -6002,7 +6002,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
       "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
       "requires": {
-        "glob": "^6.0.1"
+        "glob": "6.0.4"
       }
     },
     "run-async": {
@@ -6011,7 +6011,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0"
+        "once": "1.4.0"
       }
     },
     "rx-lite": {
@@ -6076,7 +6076,7 @@
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
       "requires": {
-        "hoek": "2.x.x"
+        "hoek": "2.16.3"
       }
     },
     "source-map": {
@@ -6085,7 +6085,7 @@
       "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
       "dev": true,
       "requires": {
-        "amdefine": ">=0.0.4"
+        "amdefine": "1.0.1"
       }
     },
     "spdx-correct": {
@@ -6094,8 +6094,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -6110,8 +6110,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -6125,12 +6125,12 @@
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
       "requires": {
-        "debug": "^2.6.8",
-        "handle-thing": "^1.2.5",
-        "http-deceiver": "^1.2.7",
-        "safe-buffer": "^5.0.1",
-        "select-hose": "^2.0.0",
-        "spdy-transport": "^2.0.18"
+        "debug": "2.6.9",
+        "handle-thing": "1.2.5",
+        "http-deceiver": "1.2.7",
+        "safe-buffer": "5.1.2",
+        "select-hose": "2.0.0",
+        "spdy-transport": "2.1.0"
       },
       "dependencies": {
         "debug": {
@@ -6148,13 +6148,13 @@
       "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
       "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
       "requires": {
-        "debug": "^2.6.8",
-        "detect-node": "^2.0.3",
-        "hpack.js": "^2.1.6",
-        "obuf": "^1.1.1",
-        "readable-stream": "^2.2.9",
-        "safe-buffer": "^5.0.1",
-        "wbuf": "^1.7.2"
+        "debug": "2.6.9",
+        "detect-node": "2.0.3",
+        "hpack.js": "2.1.6",
+        "obuf": "1.1.2",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2",
+        "wbuf": "1.7.3"
       },
       "dependencies": {
         "debug": {
@@ -6175,13 +6175,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -6189,7 +6189,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -6200,7 +6200,7 @@
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
-        "through": "2"
+        "through": "2.3.8"
       }
     },
     "split2": {
@@ -6209,7 +6209,7 @@
       "integrity": "sha1-Fi2bGIZfAqsvKtlYVSLbm1TEgfk=",
       "dev": true,
       "requires": {
-        "through2": "~2.0.0"
+        "through2": "2.0.3"
       }
     },
     "sprintf-js": {
@@ -6223,14 +6223,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       },
       "dependencies": {
         "asn1": {
@@ -6267,9 +6267,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -6288,7 +6288,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -6297,7 +6297,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "^0.2.0"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-indent": {
@@ -6306,7 +6306,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       }
     },
     "strip-json-comments": {
@@ -6327,12 +6327,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "^4.7.0",
-        "ajv-keywords": "^1.0.0",
-        "chalk": "^1.1.1",
-        "lodash": "^4.0.0",
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.10",
         "slice-ansi": "0.0.4",
-        "string-width": "^2.0.0"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6353,8 +6353,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -6363,7 +6363,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -6374,25 +6374,25 @@
       "integrity": "sha1-xhK2ioOcfpAGybDK0o2PPwJptHU=",
       "dev": true,
       "requires": {
-        "bluebird": "^3.3.1",
-        "clean-yaml-object": "^0.1.0",
-        "coveralls": "^2.11.2",
-        "deeper": "^2.1.0",
-        "foreground-child": "^1.3.3",
-        "glob": "^7.0.0",
-        "isexe": "^1.0.0",
-        "js-yaml": "^3.3.1",
-        "nyc": "^6.6.1",
-        "only-shallow": "^1.0.2",
-        "opener": "^1.4.1",
+        "bluebird": "3.3.4",
+        "clean-yaml-object": "0.1.0",
+        "coveralls": "2.13.3",
+        "deeper": "2.1.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.2",
+        "isexe": "1.1.2",
+        "js-yaml": "3.5.5",
+        "nyc": "6.6.1",
+        "only-shallow": "1.2.0",
+        "opener": "1.4.3",
         "os-homedir": "1.0.1",
-        "readable-stream": "^2.0.2",
-        "signal-exit": "^3.0.0",
-        "stack-utils": "^0.4.0",
-        "supports-color": "^1.3.1",
-        "tap-mocha-reporter": "0.0 || 1",
-        "tap-parser": "^1.2.2",
-        "tmatch": "^2.0.1"
+        "readable-stream": "2.0.6",
+        "signal-exit": "3.0.2",
+        "stack-utils": "0.4.0",
+        "supports-color": "1.3.1",
+        "tap-mocha-reporter": "0.0.27",
+        "tap-parser": "1.3.2",
+        "tmatch": "2.0.1"
       },
       "dependencies": {
         "glob": {
@@ -6401,12 +6401,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "isexe": {
@@ -6435,15 +6435,15 @@
       "integrity": "sha1-svcvPh6Lp4DuApGPzes6QNqAGPc=",
       "dev": true,
       "requires": {
-        "color-support": "^1.1.0",
-        "debug": "^2.1.3",
-        "diff": "^1.3.2",
-        "escape-string-regexp": "^1.0.3",
-        "glob": "^7.0.5",
-        "js-yaml": "^3.3.1",
-        "readable-stream": "^1.1.13",
-        "tap-parser": "^1.0.4",
-        "unicode-length": "^1.0.0"
+        "color-support": "1.1.3",
+        "debug": "2.6.9",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "js-yaml": "3.5.5",
+        "readable-stream": "1.1.14",
+        "tap-parser": "1.3.2",
+        "unicode-length": "1.0.3"
       },
       "dependencies": {
         "debug": {
@@ -6461,12 +6461,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "isarray": {
@@ -6483,10 +6483,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         }
       }
@@ -6497,10 +6497,10 @@
       "integrity": "sha1-EgxQiciMPIp5PvKIhn3jIeGPjCI=",
       "dev": true,
       "requires": {
-        "events-to-array": "^1.0.1",
-        "inherits": "~2.0.1",
-        "js-yaml": "^3.2.7",
-        "readable-stream": "^2"
+        "events-to-array": "1.1.2",
+        "inherits": "2.0.3",
+        "js-yaml": "3.5.5",
+        "readable-stream": "2.0.6"
       }
     },
     "tempfile": {
@@ -6509,8 +6509,8 @@
       "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "^1.0.0",
-        "uuid": "^2.0.1"
+        "os-tmpdir": "1.0.2",
+        "uuid": "2.0.3"
       },
       "dependencies": {
         "uuid": {
@@ -6544,8 +6544,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -6560,13 +6560,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -6575,7 +6575,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -6596,7 +6596,7 @@
       "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
       "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
       "requires": {
-        "hoek": "5.x.x"
+        "hoek": "5.0.3"
       },
       "dependencies": {
         "hoek": {
@@ -6611,7 +6611,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       }
     },
     "trim-newlines": {
@@ -6637,7 +6637,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "typedarray": {
@@ -6652,9 +6652,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "async": "~0.2.6",
-        "optimist": "~0.3.5",
-        "source-map": "~0.1.7"
+        "async": "0.2.10",
+        "optimist": "0.3.7",
+        "source-map": "0.1.43"
       },
       "dependencies": {
         "async": {
@@ -6671,7 +6671,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "wordwrap": "~0.0.2"
+            "wordwrap": "0.0.3"
           }
         }
       }
@@ -6688,8 +6688,8 @@
       "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
       "dev": true,
       "requires": {
-        "punycode": "^1.3.2",
-        "strip-ansi": "^3.0.1"
+        "punycode": "1.4.1",
+        "strip-ansi": "3.0.1"
       }
     },
     "user-home": {
@@ -6698,7 +6698,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "util-deprecate": {
@@ -6717,8 +6717,8 @@
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "validator": {
@@ -6732,8 +6732,8 @@
       "integrity": "sha1-GR2p/p3EzWjQ0USY1OKpEP9OZRY=",
       "optional": true,
       "requires": {
-        "redeyed": "~1.0.1",
-        "through": "~2.3.4"
+        "redeyed": "1.0.1",
+        "through": "2.3.8"
       }
     },
     "vasync": {
@@ -6759,9 +6759,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.2.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -6777,7 +6777,7 @@
       "integrity": "sha512-78SMe7To9U7kqVhSoGho3GfspA089ZDBIj2f8jElg2hi6lUCoagtDJ8sSMFNlpAh5Ib8Jt1gQ6Y7gh9mzHtFng==",
       "dev": true,
       "requires": {
-        "foreachasync": "^3.0.0"
+        "foreachasync": "3.0.0"
       }
     },
     "wbuf": {
@@ -6785,7 +6785,7 @@
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "requires": {
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "1.0.1"
       }
     },
     "which": {
@@ -6794,7 +6794,7 @@
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "wordwrap": {
@@ -6814,7 +6814,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "xtend": {
@@ -6833,7 +6833,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "4.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "csv-parse": "1.0.4",
     "deep-equal": "1.0.1",
     "ip": "1.1.3",
-    "ip-reputation-js-client": "3.0.1",
+    "ip-reputation-js-client": "4.0.1",
     "lodash.isequal": "4.5.0",
     "lodash.merge": "4.6.0",
     "memcached": "2.2.1",

--- a/test/test_reputation_server_stub.js
+++ b/test/test_reputation_server_stub.js
@@ -20,7 +20,7 @@ var reputationsByIp = {}
 
 server.put('/violations/:ip', function (req, res, next) {
   var ip = req.params.ip
-  mostRecentViolationByIp[ip] = req.body.Violation
+  mostRecentViolationByIp[ip] = req.body.violation
   console.log('put req', req.url)
   res.send(200)
   next()
@@ -52,7 +52,7 @@ server.get('/:ip', function (req, res, next) {
   if (ip === '9.9.9.9') {
     res.send(500)
   } else if (reputationsByIp.hasOwnProperty(ip)) {
-    res.send(200, {Reputation: reputationsByIp[ip]})
+    res.send(200, {reputation: reputationsByIp[ip]})
   } else {
     res.send(404)
   }


### PR DESCRIPTION
Update ip-reputation-js-client to v4 which includes the changes:

* remove the add method (I don't see customs-server using this anywhere)
* downcased field names (fixed Reputation to reputation and Violation to violation; don't see any other occurrences)
* switch to the memcached backed [iprepd](https://github.com/mozilla-services/iprepd) backend
* add eslint changes and fixes

cc @ameihm0912 who wants to make sure the client tracks failed requests and latency (in this PR or a new separate one)