### PR TITLE
fix(tests): remove bash builtin from test-local.sh

### DIFF
--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -18,6 +18,6 @@ fi
 
 tap test/local test/remote $cov
 
-if [[ $MC ]]; then
+if [ -n $MC ]; then
   kill $MC
 fi


### PR DESCRIPTION
test-local.sh specifies /bin/sh as an interpreter, but contains the [[
bash builtin which fails on systems where /bin/sh is not bash or is
running in a compatibility mode.

Updates test-local.sh to use a standard test command.