### PR TITLE
Updates to reputation service integration

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1948,9 +1948,9 @@
       "integrity": "sha1-ErFilKOJJUhtYYoRA1BuTrT4spY="
     },
     "ip-reputation-js-client": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/ip-reputation-js-client/-/ip-reputation-js-client-4.0.1.tgz",
-      "integrity": "sha512-R6aIpkpr4/AhxK2G5VwduxFcM2o7yka7KGVuUyV/5yQHIQoSD26vZ5zisaOsPyeEDJ2UuXQzxDvqLqYiFj3Lcg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ip-reputation-js-client/-/ip-reputation-js-client-4.0.2.tgz",
+      "integrity": "sha512-+zDcQz1nQorSukbCa0CIO7W8RpLzaC1kFHtyVuRLejwax6oWXhGzy60ODB+lkUQkTy6RmR/K8XTGzK/xHGlqTQ==",
       "requires": {
         "bluebird": "3.5.1",
         "joi": "13.3.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "csv-parse": "1.0.4",
     "deep-equal": "1.0.1",
     "ip": "1.1.3",
-    "ip-reputation-js-client": "4.0.1",
+    "ip-reputation-js-client": "4.0.2",
     "lodash.isequal": "4.5.0",
     "lodash.merge": "4.6.0",
     "memcached": "2.2.1",

--- a/test/test_reputation_server_stub.js
+++ b/test/test_reputation_server_stub.js
@@ -26,7 +26,7 @@ server.put('/violations/:ip', function (req, res, next) {
   next()
 })
 
-// not real tigerblood endpoints
+// not real iprepd endpoints
 server.get('/mostRecentViolation/:ip', function (req, res, next) {
   var ip = req.params.ip
   console.log('get req', req.url)
@@ -52,7 +52,7 @@ server.get('/:ip', function (req, res, next) {
   if (ip === '9.9.9.9') {
     res.send(500)
   } else if (reputationsByIp.hasOwnProperty(ip)) {
-    res.send(200, {reputation: reputationsByIp[ip]})
+    res.send(200, {reputation: reputationsByIp[ip], reviewed: false})
   } else {
     res.send(404)
   }
@@ -66,14 +66,10 @@ server.del('/:ip', function (req, res, next) {
   res.send(200)
   next()
 })
-server.post('/', function (req, res, next) {
+server.put('/:ip', function (req, res, next) {
   var ip = req.params.ip
-  if (reputationsByIp.hasOwnProperty(ip)) {
-    res.send(405)
-  } else {
-    reputationsByIp[ip] = req.params.reputation
-    res.send(201)
-  }
+  reputationsByIp[ip] = req.body.reputation
+  res.send(200)
   next()
 })
 


### PR DESCRIPTION
- Update ip-reputation-js-client to 4.0.2, which contains the addition of request timing info (https://github.com/mozilla-services/ip-reputation-js-client/commit/e0d3d58e53a9c01cd46c669809f7daa0fb3a0b03)
- Include request timing info in reputation service logging
- Add tests using ip-reputation-js-client to confirm addition of timing data
- Update stub reputation service to remove a deprecated endpoint