### PR TITLE
test(reputation): adds compose based integration test with iprepd

### DIFF
--- a/test/integration/reputation/README.md
+++ b/test/integration/reputation/README.md
@@ -1,0 +1,13 @@
+Reputation Service Integration Tests
+====================================
+
+Executes integration tests between fxa-customs-server and an instance
+of the iprepd daemon.
+
+```
+docker build -f Dockerfile-build -t fxa-customs-server:build .
+cd test/integration/reputation
+docker-compose build
+docker-compose run customs
+docker-compose down
+```

--- a/test/integration/reputation/docker-compose.yml
+++ b/test/integration/reputation/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3'
+
+services:
+  redis:
+    container_name: customs_redis
+    image: redis:3.2
+    ports:
+      - "6379:6379"
+
+  iprepd:
+    container_name: customs_iprepd
+    image: mozilla/iprepd:latest
+    links:
+      - redis
+    ports:
+      - "9085:9085"
+    depends_on:
+      - redis
+    volumes:
+      - ${PWD}/iprepd.yaml:/app/iprepd.yaml
+
+  memcached:
+    container_name: customs_memcached
+    image: memcached:1.4
+    ports:
+      - "11211:11211"
+
+  customs:
+    container_name: customs_app
+    image: fxa-customs-server:test
+    build:
+      context: ../../..
+      dockerfile: Dockerfile-test
+    environment:
+      MEMCACHE_ADDRESS: memcached:11211
+    links:
+      - iprepd:iprepd.host
+      - memcached
+    depends_on:
+      - iprepd
+      - memcached
+    ports:
+      - "7000:7000"
+    command: node_modules/.bin/tap test/integration/reputation/iprepd_tests.js

--- a/test/integration/reputation/iprepd.yaml
+++ b/test/integration/reputation/iprepd.yaml
@@ -1,0 +1,15 @@
+---
+listen: 0.0.0.0:9085
+redis:
+  addr: redis:6379
+auth:
+  hawk:
+    root: toor
+  disableauth: false
+violations:
+  - name: fxa:request.blockIp
+    penalty: 50
+    decreaselimit: 50
+decay:
+  points: 1
+  interval: 1m

--- a/test/integration/reputation/iprepd_tests.js
+++ b/test/integration/reputation/iprepd_tests.js
@@ -1,0 +1,187 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+var test = require('tap').test
+var TestServer = require('../../test_server')
+var Promise = require('bluebird')
+var restify = require('restify')
+var mcHelper = require('../../memcache-helper')
+
+var TEST_EMAIL = 'test@example.com'
+var TEST_IP = '192.0.2.1'
+var TEST_CHECK_ACTION = 'recoveryEmailVerifyCode'
+const ENDPOINTS = [ '/check', '/checkIpOnly' ]
+
+// wait for the violation to be sent for endpoints that respond
+// before sending violation
+var TEST_DELAY_MS = 500
+
+var config = {
+  listen: {
+    port: 7000
+  },
+  limits: {
+    rateLimitIntervalSeconds: 1
+  },
+  reputationService: {
+    enable: true,
+    enableCheck: true,
+    blockBelow: 50,
+    suspectBelow: 60,
+    baseUrl: 'http://iprepd.host:9085',
+    timeout: 25,
+    hawkId: 'root',
+    hawkKey: 'toor'
+  }
+}
+
+var repJSClientConfig = {
+  serviceUrl: config.reputationService.baseUrl,
+  id: 'root',
+  key: 'toor',
+  timeout: 25
+}
+var ipr = require('ip-reputation-js-client')
+var repJSClient = new ipr(repJSClientConfig)
+
+process.env.REPUTATION_SERVICE_ENABLE = config.reputationService.enable
+process.env.REPUTATION_SERVICE_BASE_URL = config.reputationService.baseUrl
+process.env.REPUTATION_SERVICE_TIMEOUT = config.reputationService.timeout
+process.env.REPUTATION_SERVICE_ENABLE_CHECK = config.reputationService.enableCheck
+process.env.REPUTATION_SERVICE_BLOCK_BELOW = config.reputationService.blockBelow
+process.env.REPUTATION_SERVICE_SUSPECT_BELOW = config.reputationService.suspectBelow
+process.env.REPUTATION_SERVICE_HAWK_ID = config.reputationService.hawkId
+process.env.REPUTATION_SERVICE_HAWK_KEY = config.reputationService.hawkKey
+
+var testServer = new TestServer(config)
+
+var client = restify.createJsonClient({
+  url: 'http://127.0.0.1:' + config.listen.port
+})
+
+Promise.promisifyAll(client, { multiArgs: true })
+
+test(
+  'startup test server',
+  function (t) {
+    testServer.start(function (err) {
+      t.type(testServer.server, 'object', 'test server was started')
+      t.notOk(err, 'no errors were returned')
+      t.end()
+    })
+  }
+)
+
+ENDPOINTS.forEach(endpoint => {
+  test('clear everything', t => {
+    mcHelper.clearEverything(
+      function (err) {
+        t.notOk(err, 'no errors were returned')
+        t.end()
+      }
+    )
+  })
+
+  test(`does not block ${endpoint} for IP with nonexistent reputation`, t => {
+    return repJSClient.remove(TEST_IP)
+      .then(function (response) {
+        t.equal(response.statusCode, 200, 'clears reputation in iprepd for TEST_IP')
+        return client.postAsync(endpoint, { email: TEST_EMAIL, ip: TEST_IP, action: TEST_CHECK_ACTION })
+      }).spread(function (req, res, obj) {
+        t.equal(res.statusCode, 200, 'check returns 200')
+        t.equal(obj.block, false, 'action not blocked')
+        t.end()
+      }).catch(function(err) {
+        t.fail(err)
+        t.end()
+      })
+  })
+
+  test(`does not block ${endpoint} for IP with reputation above blockBelow`, t => {
+    return repJSClient.remove(TEST_IP)
+      .then(function (response) {
+        t.equal(response.statusCode, 200, 'clears reputation in iprepd for TEST_IP')
+        return repJSClient.update(TEST_IP, 65)
+      }).then(function (response) {
+        t.equal(response.statusCode, 200, 'update reputation in iprepd for TEST_IP')
+        return client.postAsync(endpoint, { email: TEST_EMAIL, ip: TEST_IP, action: TEST_CHECK_ACTION })
+      }).spread(function (req, res, obj) {
+        t.equal(res.statusCode, 200, 'check returns 200')
+        t.equal(obj.suspect, false, 'action suspected')
+        t.equal(obj.block, false, 'action not blocked')
+        t.end()
+      }).catch(function(err) {
+        t.fail(err)
+        t.end()
+      })
+  })
+
+  test(`suspects ${endpoint} for IP with reputation below suspectBelow`, t => {
+    return repJSClient.remove(TEST_IP)
+      .then(function (response) {
+        t.equal(response.statusCode, 200, 'clears reputation in iprepd for TEST_IP')
+        return repJSClient.update(TEST_IP, 55)
+      }).then(function (response) {
+        t.equal(response.statusCode, 200, 'update reputation in iprepd for TEST_IP')
+        return client.postAsync(endpoint, { email: TEST_EMAIL, ip: TEST_IP, action: TEST_CHECK_ACTION })
+      }).spread(function (req, res, obj) {
+        t.equal(res.statusCode, 200, 'check returns 200')
+        t.equal(obj.suspect, true, 'action suspected')
+        t.equal(obj.block, false, 'action not blocked')
+        t.end()
+      }).catch(function(err) {
+        t.fail(err)
+        t.end()
+      })
+  })
+
+  test(`blocks ${endpoint} for IP with reputation below blockBelow`, t => {
+    return repJSClient.remove(TEST_IP)
+      .then(function (response) {
+        t.equal(response.statusCode, 200, 'clears reputation in iprepd for TEST_IP')
+        return repJSClient.update(TEST_IP, 20)
+      }).then(function (response) {
+        t.equal(response.statusCode, 200, 'update reputation in iprepd for TEST_IP')
+        return client.postAsync(endpoint, { email: TEST_EMAIL, ip: TEST_IP, action: TEST_CHECK_ACTION })
+      }).spread(function (req, res, obj) {
+        t.equal(res.statusCode, 200, 'check returns 200')
+        t.equal(obj.block, true, 'action blocked blocked')
+        t.equal(obj.blockReason, undefined, 'block reason not returned')
+        t.end()
+      }).catch(function(err) {
+        t.fail(err)
+        t.end()
+      })
+  })
+})
+
+test(
+  'sends violation for blocked IP from /blockIp request',
+  function (t) {
+    return repJSClient.remove(TEST_IP)
+    .then(function (response) {
+      t.equal(response.statusCode, 200, 'clears reputation in iprepd for TEST_IP')
+      return client.postAsync('/blockIp', { ip: TEST_IP })
+    }).spread(function (req, res, obj) {
+      t.equal(res.statusCode, 200, 'blockIp returns 200')
+      return Promise.delay(TEST_DELAY_MS)
+    }).then(function () {
+      return repJSClient.get(TEST_IP)
+    }).then(function (response) {
+      t.equal(response.body.reputation, 50, 'violation was applied to TEST_IP')
+      t.end()
+    }).catch(function(err) {
+      t.fail(err)
+      t.end()
+    })
+  }
+)
+
+test(
+  'teardown test server',
+  function (t) {
+    testServer.stop()
+    t.equal(testServer.server.killed, true, 'test server killed')
+    t.end()
+  }
+)

--- a/test/memcache-helper.js
+++ b/test/memcache-helper.js
@@ -10,7 +10,7 @@ P.promisifyAll(Memcached.prototype)
 
 var config = {
   memcache: {
-    address: '127.0.0.1:11211',
+    address: process.env.MEMCACHE_ADDRESS || '127.0.0.1:11211',
   },
   limits: {
     blockIntervalSeconds: 1,


### PR DESCRIPTION
Add framework for integration testing between fxa-customs-server and
iprepd (newer version of Tigerblood). The existing set of tests included a stub
reputation server; this conducts similar testing but uses the actual
reputation service backend.

Note: this doesn't actually hook it into the CI yet but can be executed manually

```
docker build -f Dockerfile-build fxa-customs-server:build
cd test/integration/reputation
docker-compose build
docker-compose run customs
docker-compose down
```