### PR TITLE
fix(restify): set server.keepAliveTimeout to 120s, similar to in node6

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -106,6 +106,14 @@ module.exports = function createServer(config, log) {
       'application/json; q=0.9': safeJsonFormatter
     }
   })
+
+  // Allow Keep-Alive connections from the auth-server to be idle up to two
+  // minutes before closing the connection. If this is not set, the default
+  // idle-time is 5 seconds.  This can cause a lot of unneeded churn in server
+  // connections. Setting this to 120s makes node8 behave more like node6. -
+  // https://nodejs.org/docs/latest-v8.x/api/http.html#http_server_keepalivetimeout
+  api.keepAliveTimeout = 120000
+
   api.use(restify.bodyParser())
 
   api.on('uncaughtException', function (req, res, route, err) {


### PR DESCRIPTION
I was looking at `tcpdump` for port 7000 on these customs<->auth sockets in stage, and correlating that with exceptions thrown on socket hang up.

The customs-server is regularly shutting down these sockets. The auth-server pool handling is doing a poor job at detecting/acting-on these close events, and regularly tries to push on a closed socket.

However, the reason this is cropping up more recently than in the past is a behaviour change in node8 http modules. See comment. (Also, a more serious problem now that we fail close on customs failures).

Should put this on master now, and look at a point release for v1.118.x customs.

r? - @mozilla/fxa-devs 
