### PR TITLE
fix(restify): set keepAliveTimeout correctly on api.server object

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -112,7 +112,7 @@ module.exports = function createServer(config, log) {
   // idle-time is 5 seconds.  This can cause a lot of unneeded churn in server
   // connections. Setting this to 120s makes node8 behave more like node6. -
   // https://nodejs.org/docs/latest-v8.x/api/http.html#http_server_keepalivetimeout
-  api.keepAliveTimeout = 120000
+  api.server.keepAliveTimeout = 120000
 
   api.use(restify.bodyParser())
 


### PR DESCRIPTION
(Same as fxa-auth-db-mysql):

Hey @vladikoff. I biffed setting this on my first try. This is the correct object location, and I've verified by watching tcpdump/netstat in stage with this fix that connections are held open until idle for 2 minutes.