### PR TITLE
refactor(server): Extract and simplify record retreival/storage, user defined rules.

### DIFF
--- a/lib/record.js
+++ b/lib/record.js
@@ -7,8 +7,21 @@ class Record {
     object = object || {}
     this.rl = object.rl       // timestamp when the account was rate-limited
     this.hits = object.hits || [] // timestamps when last hit occurred
-    this.limits = config.limits
-    this.actions = config.actions
+
+    Object.defineProperty(this, 'limits', {
+      // limits is not saved to memcached
+      enumerable: false,
+      get () {
+        return config.limits
+      }
+    })
+    Object.defineProperty(this, 'actions', {
+      // actions is not saved to memcached
+      enumerable: false,
+      get () {
+        return config.actions
+      }
+    })
     this.now = now
   }
 

--- a/lib/records.js
+++ b/lib/records.js
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (mc, reputationService, limits, recordLifetimeSeconds) {
+  const IpEmailRecord = require('./ip_email_record')(limits)
+  const EmailRecord = require('./email_record')(limits)
+  const IpRecord = require('./ip_record')(limits)
+  const UidRecord = require('./uid_record')(limits)
+  const SmsRecord = require('./sms_record')(limits)
+
+  /**
+   * Fetch a single record keyed by `key`, parse the result using `parser`.
+   *
+   * @param {String} key
+   * @param {Function} parser
+   * @returns {Promise} resolves to a Record when complete
+   */
+  async function fetchRecord(key, parser) {
+    const record = await mc.getAsync(key).then(parser, parser)
+    record.key = key
+    return record
+  }
+
+  /**
+   * Fetch a set of records
+   *
+   * @param {Object} config
+   *  @param {String} [object.ip] ip address to fetch
+   *  @param {String} [object.email] email address to fetch
+   *  @param {String} [object.phoneNumber] phone number to fetch
+   *  @param {String} [object.uid] uid to fetch
+   * @returns {Promise} resolves to an object with the following keys:
+   *  `ipRecord`, `reputation`, `emailRecord`, `ipEmailRecord`, `smsRecord`, and `uidRecord`
+   */
+  async function fetchRecords(config) {
+    const records = {}
+
+    const { ip, email, phoneNumber, uid } = config
+
+    if (ip) {
+      records.ipRecord = await fetchRecord(ip, IpRecord.parse)
+      records.reputation = await reputationService.get(ip)
+    }
+
+    // The /checkIpOnly endpoint has no email (or phoneNumber)
+    if (email) {
+      records.emailRecord = await fetchRecord(email, EmailRecord.parse)
+    }
+
+    if (ip && email) {
+      records.ipEmailRecord = await fetchRecord(ip + email, IpEmailRecord.parse)
+    }
+
+    // Check against SMS records to make sure that this request can send to this phone number
+    if (phoneNumber) {
+      records.smsRecord = await fetchRecord(phoneNumber, SmsRecord.parse)
+    }
+
+    if (uid) {
+      records.uidRecord = await fetchRecord(uid, UidRecord.parse)
+    }
+
+    return records
+  }
+
+  /**
+   * Save a record
+   *
+   * @param {Record} record
+   * @returns
+   */
+  function setRecord(record) {
+    const lifetime = Math.max(recordLifetimeSeconds, record.getMinLifetimeMS() / 1000)
+    return mc.setAsync(record.key, marshallRecordForStorage(record), lifetime)
+  }
+
+  /**
+   * Marshall a record for persistent storage
+   *
+   * @param {Record} record
+   * @returns {Object}
+   */
+  function marshallRecordForStorage (record) {
+    const marshalled = {}
+
+    for (const key of Object.keys(record)) {
+      if (key !== 'key' && typeof record[key] !== 'function') {
+        marshalled[key] = record[key]
+      }
+    }
+
+    return marshalled
+  }
+
+  /**
+   * Save records
+   *
+   * @param {Record[]} records to save.
+   * @returns {Promise} Resolves when complete
+   */
+  function setRecords(...records) {
+    return Promise.all(records.map(record => setRecord(record)))
+  }
+
+  return {
+    fetchRecord,
+    fetchRecords,
+    setRecord,
+    setRecords
+  }
+}

--- a/lib/user_defined_rules.js
+++ b/lib/user_defined_rules.js
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (config, fetchRecord, setRecords) {
+  const Record = require('./record')
+  const utils = require('./utils')
+
+  const configuredRules = config.userDefinedRateLimitRules || {}
+  // Pre compute user defined rules into a Map<action, array of rule name>
+  const computedRules = new Map()
+
+  Object.keys(configuredRules).forEach((key) => {
+    configuredRules[key].actions.forEach((action) => {
+      const items = computedRules.get(action)
+      if (! items) {
+        computedRules.set(action, [key])
+      } else {
+        computedRules.set(action, items.push(key))
+      }
+    })
+  })
+
+  return async function checkUserDefinedRateLimitRules(result, action, email, ip) {
+    // Get all the user defined rules that might apply to this action
+    const checkRules = computedRules.get(action)
+
+    // No need to check if no user defined rules
+    if (! checkRules || checkRules.length <= 0) {
+      return result
+    }
+
+    const retries = []
+    await Promise.all(checkRules.map(async (ruleName) => {
+      const recordKey = ruleName + ':' + utils.createHashHex(email, ip)
+      const record = await fetchRecord(recordKey, object => new Record(object, configuredRules[ruleName]))
+      retries.push(record.update(action))
+
+      await setRecords(record)
+    }))
+
+    const maxRetry = Math.max(retries)
+    const block = maxRetry > 0
+    const retryAfter = maxRetry || 0
+
+    // Only update the retryAfter if it has a larger rate limit
+    if (retryAfter && retryAfter > result.retryAfter) {
+      result.retryAfter = retryAfter
+      result.block = block
+    }
+
+    return result
+  }
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -502,6 +502,12 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
@@ -724,6 +730,20 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -734,6 +754,12 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "circular-json": {
       "version": "0.3.3",
@@ -1691,6 +1717,15 @@
         "map-obj": "^1.0.0"
       }
     },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
@@ -2376,6 +2411,12 @@
       "requires": {
         "is-property": "^1.0.0"
       }
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "get-pkg-repo": {
       "version": "1.4.0",
@@ -5940,6 +5981,12 @@
           "dev": true
         }
       }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "audit-filter": "0.3.0",
+    "chai": "4.2.0",
     "eslint-config-fxa": "2.1.0",
     "fxa-conventional-changelog": "1.1.0",
     "grunt": "1.0.3",

--- a/test/local/records_tests.js
+++ b/test/local/records_tests.js
@@ -1,0 +1,142 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+const { assert } = require('chai')
+const sinon = require('sinon')
+const { test } = require('tap')
+
+const sandbox = sinon.createSandbox()
+
+const mc = {
+  getAsync: sandbox.spy(() => Promise.resolve({})),
+  setAsync: sandbox.spy(() => Promise.resolve())
+}
+
+const reputationService = {
+  get: sandbox.spy(() => Promise.resolve({}))
+}
+
+const limits = {}
+
+const recordLifetimeSeconds = 1
+
+var { fetchRecords, setRecords, setRecord } = require('../../lib/records')(mc, reputationService, limits, recordLifetimeSeconds)
+
+test(
+  'fetchRecords',
+  function (t) {
+    return fetchRecords({
+      ip: 'ip address',
+      email: 'email address',
+      phoneNumber: 'phone number',
+      uid: 'uid'
+    })
+    .then(records => {
+      assert.strictEqual(mc.getAsync.callCount, 5)
+      assert.strictEqual(mc.getAsync.args[0][0], 'ip address')
+      assert.strictEqual(mc.getAsync.args[1][0], 'email address')
+      assert.strictEqual(mc.getAsync.args[2][0], 'ip addressemail address')
+      assert.strictEqual(mc.getAsync.args[3][0], 'phone number')
+      assert.strictEqual(mc.getAsync.args[4][0], 'uid')
+
+      assert.lengthOf(Object.keys(records), 6)
+      assert.isObject(records.ipRecord)
+      assert.deepEqual(records.ipRecord.key, 'ip address')
+
+      assert.isObject(records.reputation)
+
+      assert.isObject(records.emailRecord)
+      assert.strictEqual(records.emailRecord.key, 'email address')
+
+      assert.isObject(records.ipEmailRecord)
+      assert.strictEqual(records.ipEmailRecord.key, 'ip addressemail address')
+
+      assert.isObject(records.smsRecord)
+      assert.strictEqual(records.smsRecord.key, 'phone number')
+
+      assert.isObject(records.uidRecord)
+      assert.strictEqual(records.uidRecord.key, 'uid')
+
+      sandbox.reset()
+    })
+  }
+)
+
+test(
+  'setRecord',
+  function (t) {
+    const record = {
+      key: 'key',
+      getMinLifetimeMS: () => 5000,
+      value: 'record'
+    }
+
+    return setRecord(record)
+    .then(result => {
+      assert.strictEqual(mc.setAsync.callCount, 1)
+      assert.strictEqual(mc.setAsync.args[0][0], 'key')
+      assert.deepEqual(mc.setAsync.args[0][1], { value: 'record' })
+      assert.strictEqual(mc.setAsync.args[0][2], 5)
+      sandbox.reset()
+    })
+  }
+)
+
+test(
+  'setRecords',
+  function (t) {
+    const ipRecord = {
+      key: 'ip address',
+      getMinLifetimeMS: () => 5000,
+      value: 'ip record'
+    }
+    const emailRecord = {
+      key: 'email address',
+      getMinLifetimeMS: () => 5000,
+      value: 'email record'
+    }
+    const ipEmailRecord = {
+      key: 'ip addressemail address',
+      getMinLifetimeMS: () => 5000,
+      value: 'ip email record'
+    }
+    const smsRecord = {
+      key: 'phone number',
+      getMinLifetimeMS: () => 5000,
+      value: 'sms record'
+    }
+    const userDefinedRecord = {
+      key: 'user defined key',
+      getMinLifetimeMS: () => 5000,
+      value: 'user defined record'
+    }
+    Object.defineProperty(userDefinedRecord, 'not_saved', {
+      enumerable: false,
+      get () {
+        return 'not-saved-value'
+      }
+    })
+
+    return setRecords(ipRecord, emailRecord, ipEmailRecord, smsRecord, userDefinedRecord)
+      .then(records => {
+        assert.strictEqual(mc.setAsync.callCount, 5)
+        assert.strictEqual(mc.setAsync.args[0][0], 'ip address')
+        assert.deepEqual(mc.setAsync.args[0][1], { value: 'ip record' })
+
+        assert.strictEqual(mc.setAsync.args[1][0], 'email address')
+        assert.deepEqual(mc.setAsync.args[1][1], { value: 'email record' })
+
+        assert.strictEqual(mc.setAsync.args[2][0], 'ip addressemail address')
+        assert.deepEqual(mc.setAsync.args[2][1], { value: 'ip email record' })
+
+        assert.strictEqual(mc.setAsync.args[3][0], 'phone number')
+        assert.deepEqual(mc.setAsync.args[3][1], { value: 'sms record' })
+
+        assert.strictEqual(mc.setAsync.args[4][0], 'user defined key')
+        assert.deepEqual(mc.setAsync.args[4][1], { value: 'user defined record' })
+
+        sandbox.reset()
+      })
+  }
+)
+


### PR DESCRIPTION
server.js has a whole bunch of mixed concerns, part of which was record retrieval
and loading/checking user defined rules.

This PR extracts record handling logic as well as user defined rules logic
into their own modules.

Loading/saving records can now be done through a common interface. fetchRecords no longer
holds the assumption that an ip address will be passed in. setRecord no longer requires
passing in a key as the key is stored on the record, and setRecords now only accepts records
instead of it's confusing signature.  It's now possible to define non-enumerable
properties on a record that are not saved when serialized.

I started to use async/await to simplify logic where it made sense as well as
started down the path to using native promises in places.

Note, no remote tests are modified, so functionality should be the same.

This is groundwork to simplify the DataFlow integration where a simple API is
needed to fetch records of varying types.

@mozilla/fxa-devs - r?

blocks #325
